### PR TITLE
Point to lullabot/ddev-playwright

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Demo showing running isolated Drupal tests in parallel](images/demo.webp)
 
-This project, building on [deviantintegral/ddev-playwright](https://github.com/deviantintegral/ddev-playwright), enables full support for Playwright testing of Drupal websites.
+This project, building on [lullabot/ddev-playwright](https://github.com/lullabot/ddev-playwright), enables full support for Playwright testing of Drupal websites.
 
 1. Supports fast parallel tests by installing sites into sqlite databases.
 2. Enables Playwright tests to run Drush commands against a test site.


### PR DESCRIPTION
There's a redirect, but why use it?