### PR TITLE
Revert fixme and vsdiff tags as typescript build fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,17 +305,14 @@ export const config = defineVisualDiffConfig({
         {
           name: "Articles",
           path: "/en/articles",
-          tags: ["@articles"],
         },
         {
           name: "Recipes",
           path: "/en/recipes",
-          tags: ["@recipes"],
         },
         {
           name: "Alternate Recipe View",
           path: "/en/recipes-alt",
-          tags: ["@recipes"],
           skip: {
             reason: "The recipes are listed in random order",
             willBeFixedIn: "https://drupal.org/node/12345",

--- a/lib/visualdiff.d.ts
+++ b/lib/visualdiff.d.ts
@@ -54,11 +54,10 @@ export type BaseVisualDiff = {
  * A declaration that a test should be skipped.
  *
  * Nothing prevents calling test.skip() in a custom test function, but this
- * type ensures that every skip has both a reason and, optionally, a link to a
- * ticket.
+ * type ensures that every skip has both a reason and a link to a ticket.
  */
 export type SkipTest = {
     reason: string;
-    willBeFixedIn?: string;
+    willBeFixedIn: string;
     callback?: (testCase: BaseVisualDiff) => boolean;
 };

--- a/src/testcase/visualdiff.ts
+++ b/src/testcase/visualdiff.ts
@@ -69,22 +69,8 @@ export class VisualDiffTestCases {
     // Handle skipping of test cases, either based on a simple boolean or a callback.
     function doSkip(testCase: BaseVisualDiff) {
       if (typeof testCase.skip !== 'undefined' && (typeof testCase.skip.callback == 'undefined' || testCase.skip.callback(testCase))) {
-        const skipOrFixmethod = testCase.skip.willBeFixedIn ? test.fixme : test.skip;
-        const annotations = [{
-          type: 'skip reason',
-          description: testCase.skip.reason,
-        }];
-        if (testCase.skip.willBeFixedIn) {
-          annotations.push({
-            type: 'will be fixed in',
-            description: testCase.skip.willBeFixedIn
-          });
-        }
         // eslint-disable-ext-line @typescript-eslint/no-unused-vars
-        skipOrFixmethod(`${testCase.name}: ${testCase.path}`, {
-          tag: testCase.tags,
-          annotation: annotations,
-        }, async ({page}, testInfo) => {
+        test.skip(`${testCase.name}: ${testCase.skip.reason} <${testCase.skip.willBeFixedIn}>`, async ({page}, testInfo) => {
         });
       }
     }
@@ -113,9 +99,7 @@ export class VisualDiffTestCases {
             testFunction = overriddenTestFunction(testCase, group);
           }
 
-          test(`${testCase.name}: ${testCase.path}`, {
-            tag: testCase.tags
-          }, testFunction);
+          test(`${testCase.name}: ${testCase.path}`, testFunction);
         }));
       });
     });
@@ -163,7 +147,6 @@ export type BaseVisualDiff = {
   representativeUrl?: string,
   // Allow skipping of this test.
   skip?: SkipTest,
-  tags?: string[],
 }
 
 /**


### PR DESCRIPTION
I had to revert both https://github.com/Lullabot/playwright-drupal/pull/3 and https://github.com/Lullabot/playwright-drupal/pull/2 as they introduced typescript failures. I'd still love to get them in! And clearly we need to get proper building / publishing setup.