### PR TITLE
Fix detecting the hostname when multiple are configured

### DIFF
--- a/lib/testcase/test.js
+++ b/lib/testcase/test.js
@@ -110,14 +110,17 @@ var test = test_1.test.extend({
                                 switch (_a.label) {
                                     case 0:
                                         ua = (0, task_1.taskSync)('-o group playwright:ua test_id=' + id).toString();
+                                        if (!(typeof process.env.DDEV_HOSTNAME !== 'undefined')) return [3 /*break*/, 2];
                                         return [4 /*yield*/, context.addCookies([{
                                                     name: 'SIMPLETEST_USER_AGENT',
                                                     value: ua,
                                                     path: '/',
-                                                    domain: process.env.DDEV_HOSTNAME
+                                                    domain: process.env.DDEV_HOSTNAME.split(',')[0],
                                                 }])];
                                     case 1:
                                         _a.sent();
+                                        _a.label = 2;
+                                    case 2:
                                         // Mirror browser errors to the Playwright console log.
                                         context.on('weberror', function (webError) { return console.log(webError.error()); });
                                         // Clean up tests after they are complete.
@@ -127,7 +130,7 @@ var test = test_1.test.extend({
                                             (0, task_1.task)('playwright:cleanup test_id=' + id);
                                         });
                                         return [4 /*yield*/, use(context)];
-                                    case 2:
+                                    case 3:
                                         _a.sent();
                                         return [2 /*return*/];
                                 }

--- a/src/testcase/test.ts
+++ b/src/testcase/test.ts
@@ -39,12 +39,14 @@ const test = base_test.extend<TestFixture<any, any>>( {
     install.on('exit', async (code) => {
       let ua = taskSync('-o group playwright:ua test_id=' + id).toString();
 
-      await context.addCookies( [{
-        name: 'SIMPLETEST_USER_AGENT',
-        value: ua,
-        path: '/',
-        domain: process.env.DDEV_HOSTNAME
-      }]);
+      if (typeof process.env.DDEV_HOSTNAME !== 'undefined') {
+        await context.addCookies( [{
+          name: 'SIMPLETEST_USER_AGENT',
+          value: ua,
+          path: '/',
+          domain: process.env.DDEV_HOSTNAME.split(',')[0],
+        }]);
+      }
 
       // Mirror browser errors to the Playwright console log.
       context.on('weberror', (webError: WebError) => console.log(webError.error()));


### PR DESCRIPTION
I would never have guessed `DDEV_HOSTNAME` would be a comma-separated list, but it makes sense! This splits it if needed, and uses the first one which is what we intended to use in the first place.