### PR TITLE
feat: crop a11y screenshots to violation area and optimize with ImageMagick

### DIFF
--- a/src/github/a11y-summary.ts
+++ b/src/github/a11y-summary.ts
@@ -1,5 +1,7 @@
 import * as fs from 'fs'
+import * as os from 'os'
 import * as path from 'path'
+import { spawnSync } from 'child_process'
 
 /**
  * GitHub's limit for `$GITHUB_STEP_SUMMARY` content is 1 MiB — above that the
@@ -9,10 +11,10 @@ import * as path from 'path'
 const MAX_SUMMARY_BYTES = 900_000
 
 /**
- * Per-screenshot byte cap. Base64 inflates size by ~33%, so at 150 KiB we
- * keep each embedded image around 200 KiB on the wire. Larger screenshots
- * are dropped with a note — we can't resize PNGs without pulling in an
- * image library.
+ * Per-screenshot byte cap (checked after imagemagick optimisation). Base64
+ * inflates size by ~33%, so at 150 KiB we keep each embedded image around
+ * 200 KiB on the wire. Screenshots that still exceed this after optimisation
+ * are dropped with a note — they are still visible in the Playwright HTML report.
  */
 const MAX_SCREENSHOT_BYTES = 150_000
 
@@ -344,16 +346,58 @@ function detectImageMime(bytes: Buffer): string {
 }
 
 /**
+ * Attempt to shrink a screenshot with ImageMagick: resize to at most 1 200 px
+ * wide and re-encode as JPEG at quality 75. This is intentionally best-effort
+ * — if `convert` is unavailable or fails the original bytes are returned
+ * unchanged so callers always get usable output.
+ *
+ * The optimised JPEG is only returned when it is smaller than the input;
+ * otherwise the original bytes are returned.
+ */
+function optimizeScreenshot(bytes: Buffer): Buffer {
+  let tmpDir: string | undefined
+  try {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'a11y-screenshot-'))
+    const inputPath = path.join(tmpDir, 'input.png')
+    const outputPath = path.join(tmpDir, 'output.jpg')
+    fs.writeFileSync(inputPath, bytes)
+
+    const result = spawnSync('convert', [
+      inputPath,
+      '-resize', '1200x>',  // Shrink to max 1 200 px wide; never upscale.
+      '-strip',              // Strip metadata (EXIF, ICC profiles, comments).
+      '-quality', '75',
+      outputPath,
+    ], { timeout: 15_000 })
+
+    if (result.status === 0 && fs.existsSync(outputPath)) {
+      const optimized = fs.readFileSync(outputPath)
+      // Prefer the optimised version only when it is genuinely smaller.
+      return optimized.length < bytes.length ? optimized : bytes
+    }
+  } catch {
+    // ImageMagick not installed or conversion failed — use original bytes.
+  } finally {
+    if (tmpDir) {
+      try { fs.rmSync(tmpDir, { recursive: true }) } catch { /* best-effort */ }
+    }
+  }
+  return bytes
+}
+
+/**
  * Render a violation screenshot as an inline base64 image.
  *
- * Returns null if the buffer is larger than MAX_SCREENSHOT_BYTES. Oversized
- * images are dropped rather than resized — users can still see the full
- * screenshot in the Playwright HTML report.
+ * Attempts to optimise the image with ImageMagick before embedding. Returns
+ * null if the buffer is still larger than MAX_SCREENSHOT_BYTES after
+ * optimisation — users can still see the screenshot in the Playwright HTML
+ * report.
  */
 function renderScreenshot(screenshot: Buffer): string[] | null {
-  if (screenshot.length > MAX_SCREENSHOT_BYTES) return null
-  const mime = detectImageMime(screenshot)
-  const b64 = screenshot.toString('base64')
+  const optimized = optimizeScreenshot(screenshot)
+  if (optimized.length > MAX_SCREENSHOT_BYTES) return null
+  const mime = detectImageMime(optimized)
+  const b64 = optimized.toString('base64')
   return [
     '<details>',
     '<summary>Violation screenshot</summary>\n',

--- a/src/util/accessible-screenshot.test.ts
+++ b/src/util/accessible-screenshot.test.ts
@@ -227,7 +227,9 @@ describe('checkAccessibility', () => {
       .mockResolvedValueOnce(wcagResults)       // WCAG
 
     const mockPage = {
-      evaluate: vi.fn().mockResolvedValue(undefined),
+      // First evaluate: inject styles + return bounding rect (null = no elements found).
+      // Second evaluate: remove styles.
+      evaluate: vi.fn().mockResolvedValue(null),
       screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
     }
     const testInfo = makeTestInfo()
@@ -236,15 +238,64 @@ describe('checkAccessibility', () => {
       screenshotViolations: true,
     })
 
-    // Should have injected highlight styles and then removed them.
+    // Should have injected highlight styles (combined with bounds) and then removed them.
     expect(mockPage.evaluate).toHaveBeenCalledTimes(2)
-    // Should have taken a full-page screenshot.
+    // When no bounding rect is found, falls back to full-page screenshot.
     expect(mockPage.screenshot).toHaveBeenCalledWith({ fullPage: true })
     // Should have attached the screenshot.
     expect(testInfo.attach).toHaveBeenCalledWith('a11y-violation-screenshot', {
       body: Buffer.from('fake-png'),
       contentType: 'image/png',
     })
+  })
+
+  it('crops screenshot to violation bounding rect when elements are found', async () => {
+    const wcagResults = makeAxeResults({
+      violations: [{
+        id: 'color-contrast',
+        description: 'test',
+        impact: 'serious',
+        helpUrl: 'https://example.com',
+        nodes: [{ target: ['.bad-element'] }],
+      }],
+    })
+
+    mockAnalyze
+      .mockResolvedValueOnce(makeAxeResults()) // best-practice
+      .mockResolvedValueOnce(wcagResults)       // WCAG
+
+    const mockPage = {
+      // First evaluate: inject styles + return bounding rect of violation elements.
+      // Second evaluate: remove styles.
+      evaluate: vi.fn()
+        .mockResolvedValueOnce({ x: 50, y: 200, width: 400, height: 80 })
+        .mockResolvedValue(null),
+      screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
+    }
+    const testInfo = makeTestInfo()
+
+    await checkAccessibility(mockPage as any, testInfo as any, {
+      screenshotViolations: true,
+    })
+
+    // Should have taken a cropped screenshot with padding applied.
+    expect(mockPage.screenshot).toHaveBeenCalledWith({
+      clip: {
+        x: expect.any(Number),
+        y: expect.any(Number),
+        width: expect.any(Number),
+        height: expect.any(Number),
+      },
+    })
+    const callArgs = mockPage.screenshot.mock.calls[0][0]
+    // x should be clamped to 0 (50 - 100 padding = -50 → 0).
+    expect(callArgs.clip.x).toBe(0)
+    // y should be 200 - 100 padding = 100.
+    expect(callArgs.clip.y).toBe(100)
+    // width should be 400 + 200 (2× padding).
+    expect(callArgs.clip.width).toBe(600)
+    // height should be 80 + 200 (2× padding).
+    expect(callArgs.clip.height).toBe(280)
   })
 
   it('does not take a screenshot when screenshotViolations is true but no violations', async () => {
@@ -277,13 +328,14 @@ describe('checkAccessibility', () => {
       .mockResolvedValueOnce(wcagResults)       // WCAG
 
     const mockPage = {
-      evaluate: vi.fn().mockResolvedValue(undefined),
+      evaluate: vi.fn().mockResolvedValue(null),
       screenshot: vi.fn().mockResolvedValue(Buffer.from('fake-png')),
     }
     const testInfo = makeTestInfo()
 
     await checkAccessibility(mockPage as any, testInfo as any)
 
+    // No bounding rect found → falls back to full-page screenshot.
     expect(mockPage.screenshot).toHaveBeenCalledWith({ fullPage: true })
   })
 

--- a/src/util/accessible-screenshot.ts
+++ b/src/util/accessible-screenshot.ts
@@ -266,9 +266,20 @@ async function runWcagScan(
   return results
 }
 
+/** Padding in CSS pixels around the violation bounding rect when cropping. */
+const CROP_PADDING = 100
+
 /**
- * Take a full-page screenshot with violating elements highlighted and
- * attach it to the test report.
+ * Maximum crop height in CSS pixels. Caps the screenshot when violations are
+ * spread far apart on a long page so the embedded image stays manageable.
+ */
+const MAX_CROP_HEIGHT = 2000
+
+/**
+ * Take a screenshot with violating elements highlighted and attach it to the
+ * test report. The screenshot is cropped to the bounding rect of all violating
+ * elements (plus padding) rather than capturing the full page, keeping the
+ * image small enough to embed in the GitHub step summary.
  */
 async function screenshotViolatingElements(page: Page, testInfo: TestInfo, results: axe.AxeResults) {
   // Collect all raw CSS selectors from violation nodes.
@@ -279,8 +290,10 @@ async function screenshotViolatingElements(page: Page, testInfo: TestInfo, resul
 
   if (selectors.length === 0) return
 
-  // Inject highlight outlines on all violating elements.
-  await page.evaluate((sels) => {
+  // Inject highlight outlines on all violating elements and, in the same
+  // evaluate call, compute the union bounding rect in document coordinates
+  // (viewport rect + scroll offset) so we know where to crop.
+  const violationBounds = await page.evaluate((sels) => {
     const style = document.createElement('style')
     style.setAttribute('data-a11y-highlight', 'true')
     // Use a CSS rule for each selector so the outline persists even if
@@ -288,9 +301,51 @@ async function screenshotViolatingElements(page: Page, testInfo: TestInfo, resul
     const rules = sels.map(s => `${s} { outline: 3px solid #e53e3e !important; outline-offset: 2px !important; }`).join('\n')
     style.textContent = rules
     document.head.appendChild(style)
+
+    // Compute the union bounding rect of all violating elements in document
+    // coordinates. getBoundingClientRect() returns viewport-relative coords;
+    // adding scrollX/scrollY converts to page-absolute coordinates that
+    // Playwright's clip option expects.
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+    for (const sel of sels) {
+      try {
+        const elements = document.querySelectorAll(sel)
+        for (const el of elements) {
+          const rect = el.getBoundingClientRect()
+          // Skip zero-size elements (hidden or collapsed).
+          if (rect.width === 0 && rect.height === 0) continue
+          minX = Math.min(minX, rect.left + window.scrollX)
+          minY = Math.min(minY, rect.top + window.scrollY)
+          maxX = Math.max(maxX, rect.right + window.scrollX)
+          maxY = Math.max(maxY, rect.bottom + window.scrollY)
+        }
+      } catch {
+        // Invalid selector — skip.
+      }
+    }
+
+    return minX === Infinity
+      ? null
+      : { x: minX, y: minY, width: maxX - minX, height: maxY - minY }
   }, selectors)
 
-  const screenshot = await page.screenshot({ fullPage: true })
+  // Crop to the violation area with padding. Fall back to full-page when no
+  // bounding rect could be computed (e.g. all elements are hidden).
+  let screenshotOptions: Parameters<typeof page.screenshot>[0]
+
+  if (violationBounds) {
+    const x = Math.max(0, violationBounds.x - CROP_PADDING)
+    const y = Math.max(0, violationBounds.y - CROP_PADDING)
+    const width = violationBounds.width + 2 * CROP_PADDING
+    // Cap height so violations spread across a very long page don't produce a
+    // huge image. The GitHub summary embeds this as inline base64.
+    const height = Math.min(violationBounds.height + 2 * CROP_PADDING, MAX_CROP_HEIGHT)
+    screenshotOptions = { clip: { x, y, width, height } }
+  } else {
+    screenshotOptions = { fullPage: true }
+  }
+
+  const screenshot = await page.screenshot(screenshotOptions)
 
   await testInfo.attach('a11y-violation-screenshot', {
     body: screenshot,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "noImplicitAny": true,
     "esModuleInterop": true,
     "types": ["node"],
-    "lib": ["es2022", "dom"],
+    "lib": ["es2022", "dom", "dom.iterable"],
     "skipLibCheck": true
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary

- **Playwright crop**: Instead of a full-page screenshot, capture only the union bounding rect of all violating elements (+ 100 px padding, capped at 2 000 px height). The bounding rect computation is merged into the existing highlight-injection `page.evaluate()` call so the call count stays at 2. Falls back to `{ fullPage: true }` when no bounding rect can be determined (e.g. all elements hidden).

- **ImageMagick optimization**: `a11y-summary.ts` now runs `convert` on each screenshot before embedding: resize to ≤ 1 200 px wide, strip metadata, re-encode as JPEG at quality 75. Best-effort — original bytes are used transparently when ImageMagick is unavailable or the input isn't a valid image (so all existing tests still pass).

- **Action bug-fixes** (discovered via lullabot/lullabot.com-d8#5332):
  - `ddev exec` was missing `-d`, so `npx` couldn't find the locally-installed binary and fetched from the registry instead.
  - Summary stdout was not piped to `$GITHUB_STEP_SUMMARY` — that env var points to a runner-side file, not accessible inside the DDEV container.
  - Added a `playwright-dir` input (default `/var/www/html/test/playwright`) for projects with non-standard install locations.
  - Fixed corresponding README CLI examples (missing `-d` and `>> $GITHUB_STEP_SUMMARY`).

## Test plan

- [ ] All 104 unit tests pass (`npm run test:unit`)
- [ ] New test `'crops screenshot to violation bounding rect when elements are found'` verifies clip coordinates including the `x=0` clamp when padding would go negative
- [ ] Existing screenshot tests unchanged: evaluate call count stays at 2, fallback to `{ fullPage: true }` when bounding rect is null
- [ ] `optimizeScreenshot` is best-effort: invalid buffers (as used in existing tests) cause ImageMagick to fail silently and original bytes are returned — all existing screenshot-size tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)