### PR TITLE
fix(a11y-annotations): run npx in playwright dir and pipe summary to step summary

### DIFF
--- a/.github/actions/a11y-annotations/action.yml
+++ b/.github/actions/a11y-annotations/action.yml
@@ -3,13 +3,17 @@ description: 'Surface accessibility violations in GitHub workflow summaries and 
 
 inputs:
   report-path:
-    description: 'Path to Playwright JSON report'
+    description: 'Path to Playwright JSON report, relative to playwright-dir'
     required: false
     default: 'test-results/results.json'
   mode:
     description: 'Output mode: all, summary, or annotations'
     required: false
     default: 'all'
+  playwright-dir:
+    description: 'Absolute path inside the DDEV container where Playwright is installed'
+    required: false
+    default: '/var/www/html/test/playwright'
 
 runs:
   using: 'composite'
@@ -21,11 +25,15 @@ runs:
       shell: bash
       env:
         REPORT_PATH: ${{ inputs.report-path }}
-      run: ddev exec npx playwright-drupal-a11y-summary --mode=summary --report-path="$REPORT_PATH"
+        PLAYWRIGHT_DIR: ${{ inputs.playwright-dir }}
+      # Run inside the Playwright install directory so npx resolves the local
+      # binary rather than fetching it from the registry.
+      run: ddev exec -d "$PLAYWRIGHT_DIR" npx playwright-drupal-a11y-summary --mode=summary --report-path="$REPORT_PATH"
 
     - name: Accessibility annotations
       if: ${{ inputs.mode == 'all' || inputs.mode == 'annotations' }}
       shell: bash
       env:
         REPORT_PATH: ${{ inputs.report-path }}
-      run: ddev exec npx playwright-drupal-a11y-summary --mode=annotations --report-path="$REPORT_PATH"
+        PLAYWRIGHT_DIR: ${{ inputs.playwright-dir }}
+      run: ddev exec -d "$PLAYWRIGHT_DIR" npx playwright-drupal-a11y-summary --mode=annotations --report-path="$REPORT_PATH"

--- a/.github/actions/a11y-annotations/action.yml
+++ b/.github/actions/a11y-annotations/action.yml
@@ -27,8 +27,10 @@ runs:
         REPORT_PATH: ${{ inputs.report-path }}
         PLAYWRIGHT_DIR: ${{ inputs.playwright-dir }}
       # Run inside the Playwright install directory so npx resolves the local
-      # binary rather than fetching it from the registry.
-      run: ddev exec -d "$PLAYWRIGHT_DIR" npx playwright-drupal-a11y-summary --mode=summary --report-path="$REPORT_PATH"
+      # binary rather than fetching it from the registry. Pipe stdout to
+      # $GITHUB_STEP_SUMMARY from the host shell — $GITHUB_STEP_SUMMARY is a
+      # runner-side file path that is not accessible inside the DDEV container.
+      run: ddev exec -d "$PLAYWRIGHT_DIR" npx playwright-drupal-a11y-summary --mode=summary --report-path="$REPORT_PATH" >> "$GITHUB_STEP_SUMMARY"
 
     - name: Accessibility annotations
       if: ${{ inputs.mode == 'all' || inputs.mode == 'annotations' }}

--- a/README.md
+++ b/README.md
@@ -813,7 +813,7 @@ For more control, use the `playwright-drupal-a11y-summary` CLI:
 ```yaml
 - name: Accessibility summary
   if: always()
-  run: ddev exec -d /var/www/html/test/playwright npx playwright-drupal-a11y-summary --mode=summary
+  run: ddev exec -d /var/www/html/test/playwright npx playwright-drupal-a11y-summary --mode=summary >> "$GITHUB_STEP_SUMMARY"
 
 - name: Accessibility annotations
   if: always()

--- a/README.md
+++ b/README.md
@@ -785,7 +785,7 @@ Add the following to your GitHub Actions workflow:
 
 ```yaml
 - name: Run Playwright tests
-  run: ddev exec npx playwright test
+  run: ddev exec -d /var/www/html/test/playwright npx playwright test
 
 - name: Accessibility annotations
   if: always()
@@ -802,8 +802,9 @@ This step will:
 
 | Input | Default | Description |
 |-------|---------|-------------|
-| `report-path` | `test-results/results.json` | Path to the Playwright JSON report |
+| `report-path` | `test-results/results.json` | Path to the Playwright JSON report, relative to `playwright-dir` |
 | `mode` | `all` | Output mode: `all`, `summary`, or `annotations` |
+| `playwright-dir` | `/var/www/html/test/playwright` | Absolute path inside the DDEV container where Playwright is installed |
 
 ### Using the CLI Directly
 
@@ -812,11 +813,11 @@ For more control, use the `playwright-drupal-a11y-summary` CLI:
 ```yaml
 - name: Accessibility summary
   if: always()
-  run: ddev exec npx playwright-drupal-a11y-summary --mode=summary
+  run: ddev exec -d /var/www/html/test/playwright npx playwright-drupal-a11y-summary --mode=summary
 
 - name: Accessibility annotations
   if: always()
-  run: ddev exec npx playwright-drupal-a11y-summary --mode=annotations
+  run: ddev exec -d /var/www/html/test/playwright npx playwright-drupal-a11y-summary --mode=annotations
 ```
 
 #### CLI Options


### PR DESCRIPTION
## Summary

Three bug fixes to the `a11y-annotations` composite action discovered while integrating with `lullabot.com-d8`:

- `ddev exec` was missing `-d`, so `npx` fell back to the registry instead of resolving the locally-installed binary.
- The summary command's stdout was not piped to `$GITHUB_STEP_SUMMARY` — that env var points to a runner-side file path that is not accessible inside the DDEV container, so the summary never made it to the workflow page.
- README CLI examples were missing the `-d` flag and the `>> "$GITHUB_STEP_SUMMARY"` redirect.

Also adds a `playwright-dir` input (default `/var/www/html/test/playwright`) so projects with a non-standard Playwright install location can use the action.

Split out from #112 (screenshot crop branch) so this fix can land independently.

## Test plan

- [ ] Run the `a11y-annotations` action against a project where Playwright lives at `/var/www/html/test/playwright` and confirm the summary shows up on the workflow run page
- [ ] Confirm `npx` resolves the local binary rather than fetching from the registry