### PR TITLE
feat(a11y): default new tests to baseline mode, preserve snapshot mode for existing

### DIFF
--- a/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/plan-08--a11y-default-baseline-for-new-tests.md
+++ b/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/plan-08--a11y-default-baseline-for-new-tests.md
@@ -1,0 +1,312 @@
+---
+id: 8
+summary: "Flip the default accessibility assertion mode (both WCAG and best-practice scans) so tests without an existing snapshot use baseline mode, auto-seeding a per-test JSON baseline file with a human-readable note, while tests with committed snapshots continue to use snapshot mode."
+created: 2026-04-14
+---
+
+# Plan: Default New A11y Tests to Baseline Mode, Preserve Snapshot Mode for Existing Tests
+
+## Original Work Order
+> Implement this: The new baseline allowlist is strictly opt-in — passing a baseline option to checkAccessibility() (or a11y.check()) switches to the new mode, otherwise toMatchSnapshot() runs as before (src/util/accessible-screenshot.ts:164-169).
+>
+> This means your stated ideal is not the current behaviour. Today:
+> - Existing tests: unchanged (good).
+> - New tests with a11y errors: also default to snapshot mode, not the new baseline flow.
+>
+> To get your desired behaviour (new tests → baseline, existing tests → snapshot), the default would need to flip to baseline mode when no snapshot file exists yet, while continuing to honor existing snapshots.
+
+## Plan Clarifications
+
+| Question | Answer |
+|---|---|
+| How to decide between snapshot and baseline when no `baseline` option is passed? | By snapshot-file existence on disk. |
+| What happens on a brand-new test in the new default with violations present? | Auto-seed a baseline file on first run. |
+| How does `--update-snapshots` behave when no snapshot exists? | It still creates a snapshot (preserves Playwright behavior, giving users an explicit opt-in to snapshot mode for new tests). |
+| Where do auto-seeded baseline files live? | Alongside snapshots, using Playwright's `testInfo.snapshotPath()` convention. |
+| How are `reason` and `willBeFixedIn` populated when auto-seeding? | Placeholder values (e.g. `TODO`) — first run passes, authors fill in later. |
+| Should the baseline JSON file be per-browser/platform (like snapshots)? | **No — one shared file per test.** Axe results are deterministic across browsers, so a single file simplifies review and avoids near-duplicate files. |
+| Which `testInfo.config.updateSnapshots` values route a snapshotless test into snapshot-mode creation? | **`all`, `changed`, and `missing`.** Only `none` leaves the test in baseline mode. This matches Playwright's default when `--update-snapshots` is passed without a value. |
+| Does the new default apply to the best-practice scan as well, or WCAG only? | **Both scans.** Best-practice scan also gets the baseline-or-snapshot dispatch so behavior is consistent. |
+| What gets written when a snapshotless test runs and has zero violations? | An empty baseline file in the new object schema: `{ "note": "No accessibility violations found", "violations": [] }`. This gives reviewers an explicit "clean" artifact and makes later-introduced violations fail loudly as unmatched. |
+| What schema should the on-disk baseline file use? | An **object** wrapper: `{ "note": string, "violations": AccessibilityBaselineEntry[] }`. Clean runs get a human-readable "No accessibility violations found" note; seeded runs get a note pointing authors at the `TODO` placeholders. |
+| What should happen on CI when a test would auto-seed? | **Seed and fail**, matching Playwright's own default behavior for a missing visual snapshot: write the file so it's downloadable from the CI artifacts, and fail the test with a clear message telling the author to commit it. Applies whether the seed is clean (zero violations) or contains TODO entries. |
+| How are multiple `checkAccessibility()` calls within a single test named? | **Counter per call**, 1:1 with Playwright's snapshot counter: `test-name-1.a11y-baseline.json`, `test-name-2.a11y-baseline.json`, etc., matching `test-name-1-<browser>-<platform>.txt` / `test-name-2-...`. |
+
+## Executive Summary
+
+Today, `checkAccessibility()` defaults to `toMatchSnapshot()` for WCAG violations and only switches to the new baseline allowlist when a `baseline` option is explicitly passed. As a result, brand-new tests that happen to have accessibility violations silently land in the older snapshot flow rather than the richer baseline flow (which tracks per-violation `reason` / `willBeFixedIn` metadata and reports stale or unmatched entries clearly).
+
+This plan changes the default selection so that the choice between snapshot mode and baseline mode is driven by whether a snapshot file already exists on disk for the test. Existing tests, which by definition have a committed snapshot, keep using snapshot mode with no behavior change. Tests that have no snapshot (new tests, or existing tests where the snapshot was deleted) default to baseline mode, auto-seeding a baseline JSON file alongside the snapshot on first run with placeholder `reason` / `willBeFixedIn` values. Developers still opt into snapshot mode for a new test the normal Playwright way — by running once with `--update-snapshots`, which will continue to generate a snapshot file and from then on pin the test to snapshot mode.
+
+The approach is backwards compatible for all tests currently committed and their snapshots, preserves the explicit `baseline` option as the highest-priority signal, and steers new accessibility work toward the baseline flow without requiring any per-test opt-in.
+
+## Context
+
+### Current State vs Target State
+
+| Current State | Target State | Why? |
+|---|---|---|
+| `checkAccessibility()` defaults to `assertSnapshot()` whenever `baseline` option is absent (`src/util/accessible-screenshot.ts:163-169`). | `checkAccessibility()` defaults to `assertSnapshot()` only when a snapshot file already exists (or `--update-snapshots` is in effect); otherwise it runs `assertBaseline()`. | We want new tests to adopt the richer baseline workflow without breaking existing tests. |
+| Brand-new tests with violations go through snapshot comparison and attach `a11y-baseline-suggestions` but still pass via `toMatchSnapshot()`. | Brand-new tests with violations write an auto-seeded baseline JSON file on first run (analogous to how Playwright writes a new snapshot), producing a structured, committable baseline. | Baseline mode yields better signal (stale-entry reporting, per-entry metadata, unmatched-only failures). |
+| Only source of baseline data is the in-code `defineAccessibilityBaseline()` array passed via `options.baseline`. | An additional source: a JSON baseline file on disk, colocated with the snapshot, loaded automatically when no explicit `baseline` option is passed. | Enables auto-seeding and keeps baselines versioned next to the tests that use them. |
+| `reason` and `willBeFixedIn` are required fields enforced for in-code baselines. | Auto-seeded JSON entries contain placeholder `TODO` values and are accepted by the matcher; surfaced to the developer via an annotation so the fields get filled in. | Allows a green first run while preserving accountability. |
+| Explicit `options.baseline` fully controls mode selection. | Explicit `options.baseline` still wins — if provided, it's used and the on-disk JSON is ignored. | Preserves the current API contract for consumers who pass baselines in code. |
+| Only the WCAG scan is affected by the new dispatch; best-practice scan keeps `toMatchSnapshot()` unconditionally. | Best-practice scan uses the same dispatch (with its own baseline file), so both scans behave consistently. | Avoids confusing mixed behavior where one scan auto-seeds and the other demands `--update-snapshots`. |
+| Snapshots are always per-browser/platform; nothing else is colocated. | A single shared `*.a11y-baseline.json` (and `*.a11y-baseline-best-practice.json`) per test, stored in the `-snapshots/` directory without a browser/platform suffix. | Axe results are deterministic across browsers; one file per test minimizes review churn. |
+| Baseline file on disk = plain array, matching in-code `AccessibilityBaseline` exactly. | Baseline file on disk = `{ note: string, violations: AccessibilityBaselineEntry[] }`. In-code API is unchanged. | The `note` makes clean-state files self-documenting and gives authors a built-in nudge to replace `TODO` placeholders. |
+
+### Background
+
+The baseline allowlist was introduced in commit `37cd52e` (`feat: add baseline allowlist and a11y fixture helper`). Its design anticipated per-test, in-code baselines via `defineAccessibilityBaseline()`. In practice, the snapshot-mode default is noisier for new tests and doesn't capture the "why we're accepting this violation" metadata that the baseline flow was built to collect.
+
+The change is intentionally scoped: we are not deprecating snapshot mode, not changing any existing snapshot, and not modifying the in-code `baseline` API. The behavioural change is a single decision point inside `checkAccessibility()` plus a small amount of I/O (reading/writing a sibling baseline JSON). Playwright already exposes `testInfo.snapshotPath()` and a way to detect `--update-snapshots` (`testInfo.config.updateSnapshots`), so both "does a snapshot exist?" and "should we write one?" can be answered without reaching outside the test runner.
+
+## Architectural Approach
+
+The change centers on a single dispatch in `checkAccessibility()`. Instead of `if (baseline) baseline-mode else snapshot-mode`, we introduce a three-way decision based on explicit option, on-disk snapshot presence, and Playwright's update-snapshots flag. A small on-disk baseline file, colocated with snapshots, gives baseline mode a persistent home when no in-code baseline is supplied.
+
+```mermaid
+flowchart TD
+    A[checkAccessibility called] --> B{options.baseline provided?}
+    B -- yes --> C[Use in-code baseline<br/>assertBaseline]
+    B -- no --> D{Snapshot file exists?}
+    D -- yes --> E[Snapshot mode<br/>assertSnapshot - unchanged]
+    D -- no --> F{updateSnapshots flag?}
+    F -- 'all' / 'changed' / 'missing' --> G[Create snapshot<br/>assertSnapshot<br/>pins test to snapshot mode]
+    F -- 'none' --> H{Baseline JSON file exists?}
+    H -- yes --> I[Load JSON baseline<br/>assertBaseline]
+    H -- no --> L{On CI?}
+    L -- yes --> M[Seed file to disk<br/>then FAIL the test<br/>matches Playwright missing-snapshot behavior]
+    L -- no, violations > 0 --> J[Auto-seed baseline JSON<br/>note: 'TODO: fill in...'<br/>violations: entries with TODO placeholders<br/>assertBaseline passes]
+    L -- no, violations = 0 --> K[Write empty baseline JSON<br/>note: 'No accessibility violations found'<br/>violations: empty<br/>assertBaseline passes]
+```
+
+### Mode Dispatch in `checkAccessibility`
+**Objective**: Replace the current binary `baseline ? baseline-mode : snapshot-mode` branch with the three-way decision above while keeping each branch's downstream behavior stable.
+
+The dispatch lives in `src/util/accessible-screenshot.ts` at the current `if (baseline) ... return assertSnapshot(...)` block. The new logic computes:
+
+1. Whether an explicit `options.baseline` was provided — highest priority, preserves today's API.
+2. Whether the WCAG snapshot file for this test exists on disk — resolved via `testInfo.snapshotPath()` and a filesystem existence check.
+3. Whether Playwright is in snapshot-update mode — read from `testInfo.config.updateSnapshots` (the value Playwright uses when `--update-snapshots` is set).
+4. Whether an on-disk baseline JSON file exists for this test.
+
+The branch chosen governs which assertion helper runs (`assertSnapshot` vs `assertBaseline`) and, in the auto-seed case, whether a baseline JSON is written before the assertion.
+
+### On-Disk Baseline File Format and Location
+**Objective**: Define a minimal, human-readable, committable JSON format for baselines that mirrors the in-code `AccessibilityBaseline` shape.
+
+- **Location**: Colocated with the WCAG snapshot but **not** dimensioned by browser/platform. Playwright stores snapshots like `foo.spec.ts-snapshots/test-name-1-chromium-linux.txt`; the baseline file lives in the same `-snapshots/` directory with a projectless name `test-name-1.a11y-baseline.json`. The `1` is Playwright's auto-incrementing per-test snapshot counter; a test that calls `checkAccessibility()` twice produces `test-name-1.a11y-baseline.json` and `test-name-2.a11y-baseline.json`, pairing 1:1 with the corresponding `test-name-N-<browser>-<platform>.txt` snapshot files. Best-practice files follow the same pattern with a `-best-practice` suffix. The filename is derived deterministically from the same snapshot identifier `assertSnapshot` already uses, with the `-<browser>-<platform>` suffix stripped and the extension swapped. Because axe results are deterministic across Chromium/Firefox/WebKit, this produces one file per call per test across all browser projects rather than N copies.
+- **Schema**: A JSON **object** with two fields:
+  - `note` (string): a human-readable summary. Set to `"No accessibility violations found"` on a clean seed and to something like `"TODO: fill in reason and willBeFixedIn for each entry"` on a seed with violations.
+  - `violations` (array): zero or more `AccessibilityBaselineEntry` objects (`rule`, `targets`, `reason`, `willBeFixedIn`). This mirrors what `defineAccessibilityBaseline()` accepts in-code.
+- **Loading**: When `options.baseline` is absent and we enter baseline mode, the helper reads the file (if present), parses its `violations` array, and passes those entries to `assertBaseline()` exactly as the in-code path does. The `note` field is informational only and is ignored by the matcher.
+- **In-code baseline API**: `defineAccessibilityBaseline()` continues to accept and return an array (unchanged) — the object wrapper is an on-disk concern only. This keeps the TS API stable.
+
+### Auto-Seeding on First Run
+**Objective**: Make a brand-new test pass on first execution while still producing a committable artifact that captures its current state — whether clean or with violations.
+
+When the decision tree reaches the "no snapshot, no JSON baseline, `updateSnapshots === 'none'`" leaf:
+
+1. Extract normalized violations from the WCAG scan (the helper `extractNormalizedViolations` already exists).
+2. If **zero violations**, prepare a clean-state payload: `{ "note": "No accessibility violations found", "violations": [] }`.
+3. If **one or more violations**, build entries with placeholder `reason: 'TODO'` and `willBeFixedIn: 'TODO'`, wrap them as `{ "note": "TODO: fill in reason and willBeFixedIn for each entry before committing.", "violations": [...] }`.
+4. Write the file to the computed path, creating any missing parent directory. Use `fs.writeFile` with `flag: 'wx'` so concurrent workers seeding the same path can't clobber each other.
+5. **Decide pass vs. fail based on environment** — see "CI vs. Local Behavior" below.
+6. Push a `testInfo.annotations` entry ("Auto-seeded a11y baseline — review the file and fill in reason / willBeFixedIn before committing") whenever the file contains at least one placeholder value.
+
+The seeding path is gated so it only runs when the file doesn't already exist, avoiding any risk of overwriting a hand-curated baseline. On subsequent runs the file is loaded normally: a newly introduced violation is unmatched against either an empty or a partially populated `violations` array and fails the test — giving correct regression signal in both clean-seed and violation-seed cases.
+
+### CI vs. Local Behavior
+**Objective**: Match Playwright's own default for missing visual snapshots — write the artifact and fail the test — so that a11y regressions cannot slip through CI by way of silent re-seeding on every ephemeral checkout.
+
+- **Local (`!process.env.CI`)**: seed the file as described above and let `assertBaseline()` run. The first run writes the file and passes; subsequent runs load the file and enforce it. Matches Playwright's local ergonomics for a missing snapshot.
+- **CI (`process.env.CI` set)**: seed the file (so it's downloadable from CI artifacts/the test output directory) *and* fail the test with a message such as `A11y baseline file was missing. Seeded to <path> — download from CI artifacts or run locally and commit the file.` This mirrors the user-visible behavior Playwright gives for a missing visual snapshot on CI: the artifact is produced for convenience, but the test fails so the missing baseline cannot go unnoticed.
+- Attach the seeded file to `testInfo` via `testInfo.attach()` on CI so it's always reachable from the HTML/trace report, even if the workspace is torn down immediately.
+- This behavior is symmetric for the WCAG and best-practice scans.
+
+### Interaction with `--update-snapshots`
+**Objective**: Preserve Playwright's standard update-snapshots ergonomics so teams have a well-known way to put a new test into snapshot mode instead of baseline mode.
+
+Playwright's `testInfo.config.updateSnapshots` takes one of four values: `'all'`, `'changed'`, `'missing'`, `'none'`. The dispatch treats **`all`, `changed`, and `missing`** as "snapshot-creating" modes — any of them, combined with a missing snapshot file, routes the test to `assertSnapshot()` and lets Playwright write the snapshot. Only `'none'` (the default when no update-snapshots flag is passed) routes to baseline mode. `'missing'` is included because it's Playwright's default value when `--update-snapshots` is passed bare, and users running that flag almost certainly intend to seed missing snapshots.
+
+For tests already in snapshot mode, `--update-snapshots` continues to work exactly as today. If no snapshot exists but a JSON baseline already exists and `updateSnapshots !== 'none'`, snapshot generation still wins; this "I want to migrate from baseline to snapshot" edge case is acceptable and documented.
+
+### Attachments and Annotations
+**Objective**: Keep existing telemetry sensible across the two modes.
+
+- `a11y-baseline-suggestions` attachment: still produced by snapshot mode as today (unchanged).
+- Baseline mode stale/unmatched annotations: unchanged.
+- New annotation on auto-seed: a single human-readable entry pointing at the placeholder `TODO` fields in the newly written file.
+- Existing `@a11y` annotation and WCAG summary annotations remain untouched.
+
+### Best-Practice Scan Parity
+**Objective**: Apply the same dispatch to the best-practice scan so both scans behave consistently.
+
+Today the best-practice scan calls `expect.soft(violationFingerprints(results)).toMatchSnapshot()` directly inside `runBestPracticeScan`. As part of this change, extract the assertion into its own helper and apply the same three-way dispatch (explicit `baseline` > snapshot-exists > `updateSnapshots !== 'none'` > baseline with auto-seed). Two details specific to the best-practice scan:
+
+- **Soft-vs-hard semantics are preserved.** Best-practice scan uses `expect.soft()` by default (when `bestPracticeMode === 'soft'`) so the WCAG scan still runs. The baseline-mode assertion for the best-practice scan uses the same soft-vs-hard behavior as today, driven by `bestPracticeMode`.
+- **Separate on-disk baseline file.** The best-practice baseline is stored next to the WCAG baseline but with a distinct suffix (e.g. `test-name-1.a11y-baseline-best-practice.json`) so the two scans don't collide.
+
+This keeps the two scans coherent: a test with no snapshots at all gets one WCAG baseline and one best-practice baseline seeded on first run; a test already using snapshots for one or both scans keeps those snapshots untouched.
+
+### Fixture Helper (`a11y.check`)
+**Objective**: Ensure the fixture helper inherits the new default transparently.
+
+The `a11y.check(options?)` fixture currently forwards to `checkAccessibility()` with the provided options. Because the new dispatch lives inside `checkAccessibility()`, the fixture surface does not change — users of `a11y.check()` receive the new default automatically, and explicit `baseline` passed through the fixture continues to win.
+
+### Tests
+**Objective**: Cover the new dispatch exhaustively.
+
+Unit / integration tests will cover:
+
+- Existing tests with a snapshot file present → snapshot mode used, JSON baseline ignored.
+- New tests with no snapshot and no JSON, violations present, **local** run → JSON auto-seeded as `{ note: "TODO: ...", violations: [...] }`, test passes, annotation emitted.
+- New tests with no snapshot and no JSON, **zero violations**, **local** run → JSON auto-seeded as `{ note: "No accessibility violations found", violations: [] }`, test passes.
+- New tests with no snapshot and no JSON, **on CI** (`process.env.CI`) → file is seeded, `testInfo.attach()` captures it, test FAILS with a directive to commit the seeded file.
+- A subsequent run of a clean-seeded test that now has violations → unmatched against empty `violations`, test fails. (Regression-signal guarantee.)
+- New tests with no snapshot but an existing JSON → JSON loaded and matched; unmatched violations fail; stale entries reported.
+- New tests run with `updateSnapshots` = `all` / `changed` / `missing` → snapshot created, no JSON written.
+- New tests with `updateSnapshots = 'none'` → baseline mode, no snapshot written.
+- Explicit `options.baseline` provided → takes precedence regardless of on-disk state.
+- **Multi-call tests**: a single test that calls `checkAccessibility()` twice produces two distinct baseline files (`…-1.a11y-baseline.json`, `…-2.a11y-baseline.json`), matched 1:1 with the snapshot counter.
+- Best-practice scan parity: all of the above also apply to the best-practice scan, using its own baseline file.
+- Single-file-per-test assertion: running the same test across chromium + firefox projects produces exactly one `.a11y-baseline.json` per call (plus one best-practice file), not one per project.
+- Regression coverage: existing snapshot-mode tests and existing in-code-baseline tests behave identically to before.
+
+## Risk Considerations and Mitigation Strategies
+
+<details>
+<summary>Technical Risks</summary>
+- **Snapshot-path resolution differs across Playwright versions**: `testInfo.snapshotPath()` API shape has evolved; we need a stable way to compute the expected WCAG-snapshot path.
+    - **Mitigation**: Reuse the same arguments/snapshot name that `expect(...).toMatchSnapshot()` already uses in `assertSnapshot`; derive the baseline file path from that single source of truth so they can't drift.
+- **False "snapshot missing" on CI due to working-dir or sharding quirks**: If the existence check runs before snapshots are fetched or with a wrong cwd, we may accidentally auto-seed.
+    - **Mitigation**: Use the absolute path returned by Playwright's snapshot APIs rather than a relative path; add a test that simulates a non-default `testDir`.
+- **Race conditions writing the JSON under parallel workers**: Two workers could both attempt to seed the same file.
+    - **Mitigation**: Playwright's per-test snapshot path is unique per test, so concurrent writes to the same path would only occur if the same test runs twice in parallel (not the default). Write using `fs.writeFile` with `flag: 'wx'` so a second writer no-ops gracefully.
+</details>
+
+<details>
+<summary>Implementation Risks</summary>
+- **Hidden regressions in mode-detection logic**: A wrong-branch decision silently changes a test's assertion behavior.
+    - **Mitigation**: Cover all four dispatch branches with explicit integration tests before landing; add a debug annotation (gated behind an env var) that prints which branch was taken.
+- **Developers commit the auto-seeded JSON with placeholder `TODO` values and never revisit**: accountability erodes.
+    - **Mitigation**: Emit a clear annotation on every run where placeholders are still present, and document the convention in the README/AGENTS docs. (No hard block — that would defeat the point of the placeholder.)
+</details>
+
+<details>
+<summary>Operational Risks</summary>
+- **CI auto-seed silently passing**: Without the CI fail-on-seed behavior, every CI run of a new test would re-seed an ephemeral baseline and pass, hiding regressions.
+    - **Mitigation**: Implemented as part of the dispatch — on CI, seed-and-fail with a clear message, matching Playwright's missing-snapshot behavior. Covered by a dedicated integration test that sets `CI=1` and asserts the test fails while the file is written and attached.
+- **Multiple `checkAccessibility()` calls in a single test create orphan baseline files when tests are renamed or re-ordered**: The per-call counter is positional, so reordering calls produces mismatched files.
+    - **Mitigation**: This is the same failure mode Playwright's positional snapshot counter has; documented in the README so authors know to re-seed when they re-order. Stale-entry annotations from `assertBaseline()` also surface orphans at runtime.
+</details>
+
+<details>
+<summary>Integration Risks</summary>
+- **In-repo consumers relying on snapshot-mode suggestions attachment for new tests**: Teams that expected snapshot mode on a test without a committed snapshot will now get baseline mode.
+    - **Mitigation**: Document the change prominently in release notes; the opt-out is simply running once with `--update-snapshots`.
+- **Explicit `baseline` users expect baseline file on disk to be irrelevant**: Make sure the on-disk JSON is only considered when `options.baseline` is absent.
+    - **Mitigation**: Dispatch order explicitly gives the in-code `baseline` option priority, and this is covered by a dedicated test.
+</details>
+
+## Success Criteria
+
+### Primary Success Criteria
+1. With no changes to a test that already has a committed WCAG snapshot, `checkAccessibility()` continues to run `toMatchSnapshot()` and produces byte-identical snapshot assertions as before.
+2. A brand-new test calling `checkAccessibility()` with violations and no snapshot, run **locally**, passes on first run, and a committable JSON baseline file appears alongside where its snapshot would have been, containing one entry per detected violation with `reason` and `willBeFixedIn` set to placeholder values. When the same run happens on **CI**, the file is still written (and attached to the test report), but the test fails with a message directing the author to commit it — mirroring Playwright's default behavior for a missing visual snapshot.
+3. A second run of that same new test (without re-seeding) loads the JSON baseline, matches all pre-existing violations, and fails only if a new, unbaselined violation appears.
+4. Running a new test once with `--update-snapshots` creates a WCAG snapshot as today, no JSON baseline is written, and subsequent runs use snapshot mode.
+5. Supplying an explicit `baseline` option to `checkAccessibility()` or `a11y.check()` behaves exactly as it does today, regardless of any on-disk JSON baseline.
+6. The work is pushed on a feature branch and a **draft pull request** is opened against `main` describing the behavioral change.
+7. All CI jobs on the draft PR pass (lint, type-check, unit tests, integration/a11y tests, docs build, and any other required checks).
+
+## Documentation
+
+- Update the project README/docs section on accessibility testing to describe the new default, the JSON baseline file convention, and the `--update-snapshots` opt-out for snapshot mode.
+- Update `AGENTS.md` (and any `.claude/skills/*` entries covering a11y testing) so assistants know that running `a11y.check()` on a new test produces a JSON baseline that must be reviewed and have its `TODO` placeholders filled in before commit.
+- Add a short changelog entry describing the behavioral change and its backwards compatibility story.
+
+## Resource Requirements
+
+### Development Skills
+- TypeScript, Playwright test APIs (`testInfo.snapshotPath`, `testInfo.config.updateSnapshots`, `testInfo.annotations`, `testInfo.attach`), and familiarity with axe-core result shapes.
+- Node filesystem APIs for the read/write of the baseline JSON.
+
+### Technical Infrastructure
+- Existing repo tooling is sufficient: `ddev exec` for Playwright runs, the existing unit-test setup for the `src/util/` helpers, and the existing integration-test harness that already exercises `checkAccessibility` in both modes.
+
+## Delivery
+
+The work ships via a feature branch and a **draft pull request** against `main`. Before marking the plan complete:
+
+- Push the branch and open a draft PR with a summary of the behavioral change, the migration story (existing snapshots unchanged, new tests auto-seed JSON baselines, `--update-snapshots` opts into snapshot mode), and a short test plan.
+- Ensure all required CI checks on the PR are green (lint, type-check, unit tests, integration/a11y tests, docs build, and any other required status checks). Do not mark the PR ready-for-review as part of this plan — leaving it as draft is the terminal state.
+
+## Integration Strategy
+
+The change is additive: it introduces a new dispatch branch and a new optional on-disk file but leaves every existing code path reachable. Consumers need no migration; existing tests keep their snapshots and existing `defineAccessibilityBaseline()` usage continues to win over on-disk state. Opt-out to snapshot mode on a new test is the already-known Playwright gesture (`--update-snapshots`).
+
+## Notes
+
+### Decision Log
+
+- **Baseline file is per-test, not per-browser/project.** Axe-core results are deterministic across browsers, so dimensioning the file the way Playwright dimensions snapshots would create near-duplicate artifacts and review churn for no benefit.
+- **On-disk schema is an object, not a bare array.** The `note` field gives clean-state files a self-documenting marker and gives seeded-with-TODOs files a visible prompt for authors. The in-code `defineAccessibilityBaseline()` API is left as an array to avoid a breaking change; the wrapper is an on-disk concern only.
+- **`updateSnapshots === 'none'` is the only baseline-routing value.** `'all'`, `'changed'`, and `'missing'` all mean "create snapshots as Playwright normally would"; only the explicit no-update mode lets baseline dispatch run.
+- **Best-practice scan participates.** Applying the new default to only the WCAG scan would leave an inconsistent seam where one scan auto-seeds and the other requires `--update-snapshots`. Both scans now share the dispatch, each with its own baseline file.
+- **Clean-state artifact is written.** Writing nothing would mean a later-introduced violation gets silently auto-baselined with `TODO` placeholders. Writing an empty `violations: []` makes the second-run regression fail correctly.
+- **CI seeds but fails.** If CI auto-seeded and passed (the naive behavior), every CI run of a new test would silently re-seed against a fresh checkout and never surface the violations. Seeding-and-failing on CI mirrors Playwright's own default for missing visual snapshots and keeps regression signal intact.
+- **Multi-call baseline files use the snapshot counter.** Requiring an explicit per-call name would push boilerplate onto every test; reusing Playwright's existing counter keeps 1:1 parity with snapshot files and the existing mental model.
+
+### Change Log
+
+- 2026-04-14: Plan created.
+- 2026-04-14: Added delivery requirement (draft PR + green CI).
+- 2026-04-14: Refinement round — clarified baseline-file dimensionality (one shared file per test), `updateSnapshots` dispatch values (`all`/`changed`/`missing` → snapshot), scope (best-practice scan now included), zero-violation seed behavior (empty file written), and on-disk schema (object wrapper with `note` field). Updated the dispatch flowchart and assertion helpers to match; added a dedicated "Best-Practice Scan Parity" section.
+- 2026-04-14: Second refinement round — added explicit **CI vs. local** behavior (CI seeds the file, attaches it, and fails the test to match Playwright's default for missing visual snapshots); clarified **multi-call** baseline naming (per-call counter, 1:1 with Playwright's snapshot counter, e.g. `test-name-1.a11y-baseline.json`, `test-name-2…`). Updated flowchart, test matrix, success criteria, and added an "Operational Risks" section.
+- 2026-04-14: Tasks generated and execution blueprint appended.
+
+## Execution Blueprint
+
+**Validation Gates:**
+- Reference: `.ai/task-manager/config/hooks/POST_PHASE.md`
+
+### Dependency Diagram
+
+```mermaid
+graph TD
+    001[Task 001: Baseline file I/O helper]
+    002[Task 002: Dispatch in checkAccessibility]
+    003[Task 003: Test the dispatch matrix]
+    004[Task 004: Update docs]
+    005[Task 005: Draft PR + green CI]
+    001 --> 002
+    002 --> 003
+    002 --> 004
+    003 --> 005
+    004 --> 005
+```
+
+### Phase 1: Foundations
+**Parallel Tasks:**
+- Task 001: Create on-disk baseline file I/O helper
+
+### Phase 2: Core Dispatch
+**Parallel Tasks:**
+- Task 002: Implement three-way dispatch in `checkAccessibility` (WCAG + best-practice) with CI vs local behaviour (depends on: 001)
+
+### Phase 3: Verify & Document
+**Parallel Tasks:**
+- Task 003: Cover the new dispatch matrix with meaningful tests (depends on: 002)
+- Task 004: Update README, AGENTS, and Claude skill docs (depends on: 002)
+
+### Phase 4: Delivery
+**Parallel Tasks:**
+- Task 005: Push branch, open draft PR, confirm CI passes (depends on: 003, 004)
+
+### Execution Summary
+- Total Phases: 4
+- Total Tasks: 5
+- Maximum Parallelism: 2 tasks (in Phase 3)
+- Critical Path Length: 4 phases

--- a/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/01--baseline-file-io-helper.md
+++ b/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/01--baseline-file-io-helper.md
@@ -1,0 +1,104 @@
+---
+id: 1
+group: "baseline-io"
+dependencies: []
+status: "completed"
+created: 2026-04-14
+skills:
+  - typescript
+---
+# Create on-disk baseline file I/O helper
+
+## Objective
+Introduce a small, standalone helper module that owns the on-disk baseline file format (`{ note, violations }`), its path derivation from Playwright's snapshot path, and the read/write operations needed by the new default dispatch. All subsequent tasks depend on this module.
+
+## Skills Required
+- `typescript` — TypeScript source, JSON I/O, Node `fs` APIs, integration with Playwright's `TestInfo`.
+
+## Acceptance Criteria
+- [ ] New module exports at minimum: a type for the on-disk baseline file (`{ note: string; violations: AccessibilityBaselineEntry[] }`), a function that resolves the on-disk baseline path for a given `testInfo` + snapshot-name-with-counter + scan kind (`'wcag' | 'best-practice'`), a function that reads+parses the file (returning `null` when absent), and a function that writes it atomically (using `fs.writeFile` with `flag: 'wx'`).
+- [ ] Path derivation strips the `-<browser>-<platform>` suffix from the snapshot basename and swaps the extension, producing e.g. `foo.spec.ts-snapshots/test-name-1.a11y-baseline.json` and `foo.spec.ts-snapshots/test-name-1.a11y-baseline-best-practice.json`.
+- [ ] Path derivation is deterministic: given the same `testInfo` and same internal snapshot counter, it returns the same path regardless of browser/project.
+- [ ] Write helper creates any missing parent directory before writing.
+- [ ] Write helper no-ops safely (no throw) when the file already exists (`flag: 'wx'` → `EEXIST` swallowed), since the dispatch gates the call on absence.
+- [ ] Reader returns typed `{ note, violations }`; malformed JSON throws with a clear error message naming the path.
+- [ ] A small, focused unit test covers the path derivation, the happy-path round-trip (write then read), and the EEXIST no-op.
+
+## Technical Requirements
+- Source location: `src/util/accessibility-baseline-file.ts` (new file).
+- Reuse the existing `AccessibilityBaselineEntry` type from `src/util/accessibility-baseline.ts`.
+- Keep the in-code `defineAccessibilityBaseline()` API unchanged — this module is strictly for on-disk files.
+- Consumers: the dispatch in `src/util/accessible-screenshot.ts` (task 2) and its tests (task 3).
+
+## Input Dependencies
+None.
+
+## Output Artifacts
+- `src/util/accessibility-baseline-file.ts`
+- A companion unit test (e.g. `src/util/accessibility-baseline-file.test.ts`) exercising path derivation and I/O.
+
+## Implementation Notes
+
+<details>
+
+**Path derivation approach.** Playwright's `testInfo.snapshotPath(...)` returns a full path like `.../foo.spec.ts-snapshots/test-name-1-chromium-linux.txt`. We want `.../foo.spec.ts-snapshots/test-name-1.a11y-baseline.json`.
+
+Steps for the path helper:
+1. Accept `(testInfo: TestInfo, snapshotName: string, kind: 'wcag' | 'best-practice')` where `snapshotName` is whatever name the assert helper passed to `toMatchSnapshot(name)` (if we pass no explicit name, Playwright auto-generates `test-name-1.txt` etc. using an internal counter). For the new flow, we will have the assert helper resolve a specific name using Playwright's internal counter semantics by calling `testInfo.snapshotPath(name)` — in practice the easiest is: ask Playwright for the snapshot path, take its `path.basename`, strip the trailing `-<browser>-<platform>` suffix (the project/platform tuple is available as `testInfo.project.name` and `process.platform`; use those to construct and trim the suffix) and swap the extension.
+2. Suffix to swap: `.txt` → `.a11y-baseline.json` (WCAG) or `.a11y-baseline-best-practice.json` (best-practice).
+3. Return an absolute path rooted in the same snapshots directory (`path.dirname(snapshotAbsPath)`).
+
+**Why derive from `snapshotPath` rather than constructing from scratch?** Any future change to Playwright's snapshot-directory layout stays transparent.
+
+**Schema types:**
+
+```ts
+import type { AccessibilityBaselineEntry } from './accessibility-baseline'
+
+export interface OnDiskBaselineFile {
+  note: string
+  violations: AccessibilityBaselineEntry[]
+}
+```
+
+**Writer:**
+
+```ts
+import { promises as fs } from 'fs'
+import path from 'path'
+
+export async function writeBaselineFile(filePath: string, data: OnDiskBaselineFile): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  try {
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', { flag: 'wx' })
+  } catch (err: any) {
+    if (err?.code === 'EEXIST') return
+    throw err
+  }
+}
+```
+
+**Reader:**
+
+```ts
+export async function readBaselineFile(filePath: string): Promise<OnDiskBaselineFile | null> {
+  let raw: string
+  try {
+    raw = await fs.readFile(filePath, 'utf8')
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null
+    throw err
+  }
+  try {
+    return JSON.parse(raw) as OnDiskBaselineFile
+  } catch (err) {
+    throw new Error(`Malformed baseline file at ${filePath}: ${(err as Error).message}`)
+  }
+}
+```
+
+**Unit tests:** use a temp directory (`os.tmpdir()` + `fs.mkdtemp`) to exercise the round-trip and the EEXIST case. Path-derivation test can stub a minimal `TestInfo`-shaped object (only the fields needed: `snapshotPath`, `project.name`, possibly `title`).
+
+All commands must be run through `ddev exec` per repo convention (e.g. `ddev exec npx vitest run src/util/accessibility-baseline-file.test.ts`). Follow whatever test runner is already used in the repo (inspect `package.json` scripts if unsure).
+
+</details>

--- a/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/02--dispatch-checkaccessibility.md
+++ b/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/02--dispatch-checkaccessibility.md
@@ -1,0 +1,125 @@
+---
+id: 2
+group: "dispatch"
+dependencies: [1]
+status: "completed"
+created: 2026-04-14
+skills:
+  - typescript
+---
+# Implement three-way dispatch in checkAccessibility (WCAG + best-practice) with CI vs local behaviour
+
+## Objective
+Replace the current `baseline ? baseline-mode : snapshot-mode` branch inside `checkAccessibility()` with the three-way dispatch described in the plan, applied to both the WCAG scan and the best-practice scan. Each branch wires up the on-disk baseline JSON (via the helper from task 1), honours `testInfo.config.updateSnapshots`, emits the correct annotations, and implements the CI-fails-after-seed behaviour.
+
+## Skills Required
+- `typescript` — edits to `src/util/accessible-screenshot.ts`, Playwright `TestInfo` APIs, annotation/attachment plumbing.
+
+## Acceptance Criteria
+- [ ] In `checkAccessibility()`, mode selection for the WCAG scan follows: (a) explicit `options.baseline` → in-code baseline mode (unchanged); else (b) if snapshot file exists on disk → snapshot mode (unchanged); else (c) if `testInfo.config.updateSnapshots` is `'all'`, `'changed'`, or `'missing'` → snapshot mode (Playwright writes the snapshot); else (d) baseline mode driven by the on-disk baseline JSON.
+- [ ] When in on-disk baseline mode and the JSON file exists, its `violations` array is parsed and passed to `assertBaseline()` (existing helper). The `note` field is ignored by the matcher.
+- [ ] When in on-disk baseline mode and the JSON file is missing, the file is seeded: `{ note: "No accessibility violations found", violations: [] }` for zero violations, or `{ note: "TODO: fill in reason and willBeFixedIn for each entry before committing.", violations: [...] }` with placeholder `reason: 'TODO'` / `willBeFixedIn: 'TODO'` for N>0 violations. The seeded file is attached to the report via `testInfo.attach()`.
+- [ ] **CI behaviour**: when `process.env.CI` is set and the dispatch takes the seeding branch, the file is still written and attached, but the test FAILS with a clear message naming the seeded path and instructing the author to download/commit it. Mirrors Playwright's default missing-snapshot behaviour.
+- [ ] **Local behaviour**: when `!process.env.CI` and the dispatch takes the seeding branch, `assertBaseline()` is called with the freshly seeded entries so the first run passes. A `testInfo.annotations` entry notes the seed (including a `TODO`-reminder when placeholders were written).
+- [ ] The best-practice scan receives the same dispatch. It uses its own on-disk baseline file (`.a11y-baseline-best-practice.json`) and preserves the existing soft/hard behaviour driven by `bestPracticeMode`. Extract the best-practice assertion into a helper function so both scans can share the dispatch cleanly.
+- [ ] Multi-call support: a single test invoking `checkAccessibility()` twice yields two distinct baseline files keyed by Playwright's snapshot counter (`-1`, `-2`). No behavioural change vs. the existing snapshot counter.
+- [ ] Existing behaviour unchanged for: (a) tests with a committed snapshot file, (b) tests that pass an explicit `options.baseline`, (c) all output attachments/annotations that exist today in both modes.
+- [ ] `src/testcase/test.ts`'s `a11y` fixture (`a11y.check`) continues to work without modification — all changes are encapsulated inside `checkAccessibility()`.
+
+## Technical Requirements
+- Target file: `src/util/accessible-screenshot.ts`.
+- Reuse `src/util/accessibility-baseline-file.ts` (task 1) for all on-disk I/O.
+- Reuse existing helpers: `assertBaseline`, `assertSnapshot`, `extractNormalizedViolations`, `violationFingerprints`, `runWcagScan`, `runBestPracticeScan`.
+- Read `testInfo.config.updateSnapshots` to gate branch (c). Valid values: `'all' | 'changed' | 'missing' | 'none'`. Only `'none'` routes to baseline mode.
+- Use `process.env.CI` for the CI branch. Do not introduce any new config flags.
+
+## Input Dependencies
+- Task 1's `accessibility-baseline-file.ts` module and its exports.
+
+## Output Artifacts
+- Modified `src/util/accessible-screenshot.ts` with the new dispatch.
+- Any small refactor needed to extract the best-practice assertion into a shared helper.
+
+## Implementation Notes
+
+<details>
+
+**Where the dispatch lives.** Today `src/util/accessible-screenshot.ts:163-169` has:
+
+```ts
+if (baseline) {
+  return assertBaseline(testInfo, wcagScanResults, baseline)
+}
+return assertSnapshot(testInfo, wcagScanResults)
+```
+
+Replace with a single new function `dispatchAssertion({ testInfo, results, explicitBaseline, scanKind })` used by both scans. Pseudocode:
+
+```ts
+async function dispatchAssertion({ testInfo, results, explicitBaseline, scanKind }): Promise<void> {
+  if (explicitBaseline) {
+    return assertBaseline(testInfo, results, explicitBaseline) // scan-specific assert
+  }
+
+  const snapshotExists = await snapshotFileExists(testInfo, scanKind)
+  if (snapshotExists) {
+    return assertSnapshot(testInfo, results, scanKind) // scan-specific assert
+  }
+
+  const update = testInfo.config.updateSnapshots
+  if (update === 'all' || update === 'changed' || update === 'missing') {
+    return assertSnapshot(testInfo, results, scanKind)
+  }
+
+  // Baseline mode via on-disk JSON.
+  const baselinePath = resolveBaselinePath(testInfo, scanKind)
+  const existing = await readBaselineFile(baselinePath)
+  if (existing) {
+    return assertBaseline(testInfo, results, existing.violations)
+  }
+
+  // Seed.
+  const seed = buildSeed(results)
+  await writeBaselineFile(baselinePath, seed)
+  await testInfo.attach(`a11y-${scanKind}-baseline-seed`, {
+    path: baselinePath,
+    contentType: 'application/json',
+  })
+
+  if (process.env.CI) {
+    expect(null, `A11y baseline file was missing. Seeded to ${baselinePath} — download from CI artifacts or run locally and commit the file.`).toBe('baseline file present')
+    return
+  }
+
+  testInfo.annotations.push({
+    type: 'Accessibility',
+    description: seed.violations.length === 0
+      ? `A11y baseline seeded at ${baselinePath} (no violations).`
+      : `A11y baseline seeded at ${baselinePath} with ${seed.violations.length} entries — fill in reason/willBeFixedIn before committing.`,
+  })
+  return assertBaseline(testInfo, results, seed.violations)
+}
+```
+
+**Snapshot existence check.** Use `testInfo.snapshotPath(...)` with the same arguments the existing `assertSnapshot` gives to `toMatchSnapshot()` (in practice `toMatchSnapshot()` auto-picks the name using an internal counter; you'll need to either pass an explicit name to `toMatchSnapshot()` and to `testInfo.snapshotPath(name)`, or use `testInfo.snapshotPath()` without args and rely on the counter tracked via `testInfo.snapshotSuffix`/internal state). Cleanest approach: pass an explicit name argument (e.g. `toMatchSnapshot('a11y-wcag')` and a different name for best-practice) so both the snapshot and the baseline filename derivation are deterministic and independent of the global counter. This also resolves scan coexistence — WCAG and best-practice no longer clash on the shared counter.
+
+If changing the snapshot name breaks existing snapshots (because today they were written without an explicit name and live at `...-1-<browser>-<platform>.txt` etc.), handle that with a fallback: if explicit-name snapshot path doesn't exist on disk but the legacy numbered path does, treat that as "snapshot exists" and continue using the numbered variant. Document the migration in the task 4 README updates.
+
+*(Alternative, simpler path: keep the auto-counter behaviour and derive the baseline file path by taking `testInfo.snapshotPath()` with no args and stripping the trailing `-<browser>-<platform>` and extension. This is what task 1's helper is set up to do.)*
+
+**Best-practice extraction.** Currently `runBestPracticeScan()` internally calls `expect.soft(violationFingerprints(results)).toMatchSnapshot()`. Refactor so that:
+- `runBestPracticeScan` returns the results and annotations as data;
+- A new `assertBestPracticeSnapshot(testInfo, results)` wraps the soft/hard `toMatchSnapshot` call (preserving `bestPracticeMode` semantics);
+- `dispatchAssertion` with `scanKind === 'best-practice'` routes to that helper when in snapshot mode, and to `assertBaseline` (soft or hard) when in baseline mode. Use `expect.soft` vs `expect` in baseline mode based on `bestPracticeMode`.
+
+**CI failure message.** The message needs to guide the developer. Sample:
+
+> `A11y baseline file was missing for <test title>. Seeded to <relative path>. Download the attached file from CI artifacts (or re-run locally) and commit it before merging.`
+
+Use `expect(null, message).toBe('baseline file present')` or equivalent assertion that always fails — do not throw raw `Error` so Playwright captures the message cleanly.
+
+**Do not break existing tests.** Run `ddev exec npx playwright test` (or the repo's equivalent) locally once the edit is in place to confirm existing integration tests still pass. Snapshot files in the repo for existing tests must continue to drive snapshot mode; the baseline branch must not be taken for them.
+
+**Keep the attachment surface consistent.** The existing `a11y-baseline-suggestions` attachment (in snapshot mode) stays unchanged. A new `a11y-wcag-baseline-seed` (and `a11y-best-practice-baseline-seed`) attachment is added only in the seeding branch.
+
+</details>

--- a/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/03--tests-dispatch-matrix.md
+++ b/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/03--tests-dispatch-matrix.md
@@ -1,0 +1,99 @@
+---
+id: 3
+group: "testing"
+dependencies: [2]
+status: "completed"
+created: 2026-04-14
+skills:
+  - typescript
+  - playwright
+---
+# Cover the new dispatch matrix with meaningful tests
+
+## Objective
+Add the minimum set of tests that exercise every branch of the new dispatch — covering existing behaviour (regression-proofing) and the new CI-vs-local, multi-call, and best-practice-parity behaviour described in the plan's Success Criteria and Tests matrix.
+
+## Skills Required
+- `typescript`, `playwright` — mix of pure unit tests for the helpers and integration tests exercising `checkAccessibility()` end-to-end.
+
+Your critical mantra for test generation is: "write a few tests, mostly integration".
+
+**Definition of "Meaningful Tests":**
+Tests that verify custom business logic, critical paths, and edge cases specific to the application. Focus on testing YOUR code, not the framework or library functionality.
+
+**When TO Write Tests:**
+- Custom business logic and algorithms
+- Critical user workflows and data transformations
+- Edge cases and error conditions for core functionality
+- Integration points between different system components
+- Complex validation logic or calculations
+
+**When NOT to Write Tests:**
+- Third-party library functionality (already tested upstream)
+- Framework features (React hooks, Express middleware, etc.)
+- Simple CRUD operations without custom logic
+- Getter/setter methods or basic property access
+- Configuration files or static data
+- Obvious functionality that would break immediately if incorrect
+
+## Acceptance Criteria
+- [ ] Integration test: an existing test with a committed snapshot file → snapshot mode is used; no JSON baseline file is created or read. (Regression coverage.)
+- [ ] Integration test: an explicit `options.baseline` is passed → in-code baseline is used regardless of any on-disk JSON present on disk. (Regression coverage.)
+- [ ] Integration test (local, `CI` unset): snapshotless test with violations → JSON file is seeded with `note` containing the `TODO` prompt and `violations` populated with placeholder `reason`/`willBeFixedIn`; test passes; annotation is emitted.
+- [ ] Integration test (local, `CI` unset): snapshotless test with zero violations → JSON file is seeded as `{ note: "No accessibility violations found", violations: [] }`; test passes.
+- [ ] Integration test (CI simulated, `CI=1`): snapshotless test with violations → JSON file is still written, attached to the test, and the test fails with a clear message naming the seeded path. Zero-violations-on-CI variant also fails (because the baseline was missing) for parity with Playwright's missing-snapshot behaviour.
+- [ ] Integration test: second run of a previously clean-seeded test (empty `violations`) that now has a violation → fails as unmatched. (Regression-signal guarantee.)
+- [ ] Integration test: a test run with `updateSnapshots` = `missing` (or `all`/`changed`) and no snapshot → snapshot is created, no JSON file is written. A separate assertion with `updateSnapshots = 'none'` on the same initial state → baseline mode, no snapshot written.
+- [ ] Integration test: a single test making two `checkAccessibility()` calls produces two distinct baseline files (`…-1.a11y-baseline.json`, `…-2.a11y-baseline.json`) matching Playwright's counter.
+- [ ] Integration test: best-practice scan exhibits the same dispatch — zero-violation seeding, non-zero seeding, CI failure, and file separation (`a11y-baseline-best-practice.json` sibling).
+- [ ] Unit coverage for the helper module from task 1 (path derivation, write-then-read round trip, EEXIST no-op).
+- [ ] All tests run under `ddev exec` per repo convention.
+
+## Technical Requirements
+- Extend the existing test harness in `src/util/accessible-screenshot.test.ts`, `src/util/accessibility-baseline.test.ts`, and the integration tests referenced by the `pwtest-*` snapshots (`test/playwright/tests/a11y-check.spec.ts`, `a11y-fixture.spec.ts`). Prefer adding to existing files over creating new ones.
+- Use temp working directories for tests that exercise file I/O, so they don't leak artifacts into the repo.
+- Simulate CI by setting `process.env.CI = '1'` in a test-scope wrapper (and restoring afterward) rather than relying on the host env.
+- Mock `testInfo.config.updateSnapshots` where needed via the same mocking pattern already used in the existing `accessibility-baseline.test.ts`.
+
+## Input Dependencies
+- Task 2's completed dispatch in `src/util/accessible-screenshot.ts`.
+
+## Output Artifacts
+- Updated test files under `src/util/` and `test/playwright/tests/` covering the matrix above.
+- All tests passing locally.
+
+## Implementation Notes
+
+<details>
+
+**Reuse existing mocking patterns.** `src/util/accessibility-baseline.test.ts` already mocks Playwright's `expect` and `testInfo` shapes; follow the same pattern. Where an integration test needs real Playwright, use the repo's existing integration harness (the `test/playwright` directory) and rely on `ddev exec npx playwright test <spec>`.
+
+**Keep tests focused.** Per "a few tests, mostly integration": one well-constructed integration spec per dispatch branch is better than a dozen unit tests for the same logic. Combine scenarios into focused specs (e.g. one file `a11y-dispatch.spec.ts` covers all the integration cases above with small per-test fixtures).
+
+**CI simulation.** The dispatch reads `process.env.CI`. To test both branches:
+
+```ts
+const originalCI = process.env.CI
+afterEach(() => {
+  if (originalCI === undefined) delete process.env.CI
+  else process.env.CI = originalCI
+})
+
+it('fails on CI when seeding a baseline', async () => {
+  process.env.CI = '1'
+  // ...
+})
+```
+
+**Cleanup.** Any baseline files written during tests live under a temp directory; clean up in `afterAll` / `afterEach` to avoid polluting the repo.
+
+**Skip existing passing tests.** The refactor in task 2 must leave existing tests green — do not rewrite them unless their assertions need to move to a new helper. A passing `playwright test` run is the primary regression gate.
+
+Run the full suite with:
+
+```
+ddev exec npx playwright test
+ddev exec npx vitest run   # or whatever unit-test command the repo uses; inspect package.json
+```
+
+</details>

--- a/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/04--docs-update.md
+++ b/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/04--docs-update.md
@@ -1,0 +1,57 @@
+---
+id: 4
+group: "documentation"
+dependencies: [2]
+status: "completed"
+created: 2026-04-14
+skills:
+  - documentation
+---
+# Update README, AGENTS, and Claude skill docs for the new default
+
+## Objective
+Document the behavioural change so library consumers and assistants know: (a) new tests default to baseline mode with an on-disk JSON file, (b) existing tests with snapshots behave unchanged, (c) `--update-snapshots` opts a new test into snapshot mode, (d) CI writes the seeded file but fails the test so it must be committed.
+
+## Skills Required
+- `documentation` — Markdown edits, clear examples, no code changes.
+
+## Acceptance Criteria
+- [ ] Top-level `README.md` accessibility section explains the new default dispatch (snapshot exists → snapshot mode; otherwise → baseline mode with on-disk JSON), the JSON file's object schema (`{ note, violations }`), the location convention (alongside snapshots, projectless, per-call counter), and the `--update-snapshots` opt-out to snapshot mode.
+- [ ] README explicitly states the CI behaviour: on `CI=1`, the dispatch seeds the file AND fails the test; developer must download the artifact (or re-run locally) and commit it.
+- [ ] README mentions that auto-seeded entries contain placeholder `TODO` values for `reason` and `willBeFixedIn` that must be filled in before merge.
+- [ ] `AGENTS.md` (and any `.claude/skills/*` entry covering a11y testing) is updated with the same information in short form so assistants don't regenerate stale guidance.
+- [ ] A short changelog/release-notes entry is added (e.g. `CHANGELOG.md` if the repo has one, otherwise a brief section in README covering the behavioural change and backwards-compat story).
+- [ ] Docs mention that the best-practice scan participates in the same dispatch and uses a separate `.a11y-baseline-best-practice.json` file.
+
+## Technical Requirements
+- Update only Markdown. Do not touch source or tests.
+- Match the existing tone and heading structure of the README a11y section.
+- If an MkDocs site is configured (`mkdocs.yml` in repo root), update the relevant page there too.
+
+## Input Dependencies
+- Task 2's dispatch is implemented (so docs describe what the code actually does). Docs can be written in parallel with task 3 (tests).
+
+## Output Artifacts
+- Updated `README.md` (a11y section).
+- Updated `AGENTS.md` and any relevant `.claude/skills/*` files.
+- Changelog entry (existing file or new section).
+- MkDocs page update if applicable.
+
+## Implementation Notes
+
+<details>
+
+**Anchor the docs on the user-facing mental model**, not the internal branches:
+
+> "Accessibility violations are pinned in one of two ways: a Playwright snapshot (the old default) or a JSON baseline file with a human-readable `note` and a `violations` array. As of this change, new tests default to the baseline file; existing tests keep their snapshots. Run with `--update-snapshots` to create a snapshot for a new test instead."
+
+**Include a short FAQ** covering the likely questions:
+- "My test passed locally but failed on CI — why?" → CI seeded the baseline file; download the artifact from the CI run and commit it.
+- "Why do I have `TODO` values in my baseline file?" → They're placeholders; fill them in with the real reason and the ticket/milestone where the violation will be fixed before merging.
+- "Can I still use `defineAccessibilityBaseline()` in code?" → Yes, unchanged; in-code baselines always take precedence.
+
+**Assistant docs** (`AGENTS.md`, `.claude/skills/*`) should be terse — a few lines pointing at the README with the key invariants.
+
+No need to inline the full decision tree in user-facing docs; keep that in the plan.
+
+</details>

--- a/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/05--draft-pr-and-ci.md
+++ b/.ai/task-manager/plans/08--a11y-default-baseline-for-new-tests/tasks/05--draft-pr-and-ci.md
@@ -1,0 +1,97 @@
+---
+id: 5
+group: "delivery"
+dependencies: [3, 4]
+status: "pending"
+created: 2026-04-14
+skills:
+  - github-actions
+  - bash
+---
+# Push branch, open draft PR, and confirm CI passes
+
+## Objective
+Ship the work: commit the implementation and docs, push the feature branch, open a **draft** pull request against `main` with a clear description and test plan, and make sure every required CI check passes green. Leave the PR in draft — per the plan, that's the terminal state.
+
+## Skills Required
+- `bash`, `github-actions` — git operations, `gh` CLI, monitoring CI.
+
+## Acceptance Criteria
+- [ ] All implementation, test, and documentation changes are committed in focused commits on the existing feature branch `feature/8--a11y-default-baseline-for-new-tests`.
+- [ ] Branch is pushed to `origin` with upstream tracking set.
+- [ ] A **draft** PR is opened against `main` using `gh pr create --draft`, with a title under ~70 chars and a body containing: summary (3–5 bullets), migration note (existing snapshots unchanged, new tests seed baselines, `--update-snapshots` opts into snapshot mode, CI seeds-and-fails), and a short test plan checklist.
+- [ ] The PR description links to or quotes the plan's Success Criteria so reviewers can cross-check.
+- [ ] All required CI status checks on the PR are green. If any check fails, diagnose and fix (do not mark ready-for-review, do not bypass checks) until all are green.
+- [ ] The PR remains in **draft** status when this task is marked complete — do NOT mark it ready-for-review.
+- [ ] The stashed `package-lock.json` change from before the feature branch was created is NOT incorporated into this PR (it was unrelated); leave it stashed for the user to handle separately.
+
+## Technical Requirements
+- Use `gh` for PR creation and CI inspection (`gh pr checks`).
+- Do not use `--no-verify` on commits; if a pre-commit hook fails, fix the underlying issue.
+- Do not force-push unless explicitly required to resolve a branch-protection rule, and never to `main`.
+
+## Input Dependencies
+- Task 3 (tests pass locally) and task 4 (docs landed) both complete.
+
+## Output Artifacts
+- A commit history on `feature/8--a11y-default-baseline-for-new-tests`.
+- A draft PR on GitHub against `main`.
+- Confirmation (logged in the execution summary) that all required CI checks are green.
+
+## Implementation Notes
+
+<details>
+
+**Commit strategy.** Prefer a small number of logical commits rather than one giant one:
+
+1. `feat(a11y): add on-disk baseline file helper` (task 1 output)
+2. `feat(a11y): default new tests to baseline mode with CI fail-on-seed` (task 2 output)
+3. `test(a11y): cover new dispatch matrix` (task 3 output)
+4. `docs(a11y): describe new baseline default` (task 4 output)
+
+All commits signed off by the Claude co-author line per repo convention.
+
+**Draft PR creation.**
+
+```bash
+gh pr create \
+  --draft \
+  --base main \
+  --head feature/8--a11y-default-baseline-for-new-tests \
+  --title "feat(a11y): default new tests to baseline mode, preserve snapshot mode for existing tests" \
+  --body "$(cat <<'EOF'
+## Summary
+- New a11y tests default to baseline mode (on-disk JSON file); existing tests with snapshots are unchanged.
+- `{ note, violations }` schema. Per-call counter, one file per test across browsers.
+- CI writes the seeded file and fails the test — matches Playwright's missing-snapshot behavior.
+- Best-practice scan gets the same dispatch with its own baseline file.
+
+## Migration
+- Existing snapshots: nothing to do.
+- New test needs snapshot mode? Run once with `--update-snapshots`.
+- New test with a11y violations: run locally, a baseline JSON is seeded with `TODO` placeholders; fill them in and commit.
+
+## Test plan
+- [ ] Existing snapshot-mode tests still green.
+- [ ] Snapshotless test with violations seeds JSON locally and passes; fails on CI with clear message.
+- [ ] Snapshotless test with zero violations seeds an empty baseline locally.
+- [ ] Explicit `options.baseline` still takes precedence.
+- [ ] Multi-call test produces per-counter files.
+- [ ] Best-practice scan uses its own baseline file.
+EOF
+)"
+```
+
+**CI monitoring.**
+
+```bash
+gh pr checks --watch
+```
+
+If a check fails, read the failing job logs, identify the root cause (lint? type error? snapshot drift? test failure?), fix on a new commit, push, and re-run the watch. Do not bypass.
+
+**Do not merge.** The terminal state for this task is a green, draft PR. Leave it as-is.
+
+**Stashed package-lock.** Before the feature branch was cut, `package-lock.json` was stashed (not on this branch). Do not restore or include it in this PR; it is out of scope for plan 8.
+
+</details>

--- a/docs/visual-comparisons.md
+++ b/docs/visual-comparisons.md
@@ -12,7 +12,34 @@ The `takeAccessibleScreenshot()` method will:
 4. Automatically trigger loading of all lazy-loaded iframes.
 5. Generate an accessibility report of the element being tested.
 
-The accessibility reports save a JSON object with all accessibility failures. Commit these to your repository to mark those failures as ignored. Pages with no failures will generate a report with an empty array (`[]`).
+## Accessibility violations: snapshot vs. baseline
+
+Each WCAG and best-practice scan is asserted in one of two modes:
+
+- **Snapshot mode** (legacy): violations are pinned via Playwright's `toMatchSnapshot()` against a `.txt` snapshot in the test's `-snapshots/` directory. Used automatically whenever the test already has a committed snapshot.
+- **Baseline mode** (new default for snapshotless tests): violations are matched against an on-disk JSON baseline file colocated with snapshots. The file uses an object schema with a human-readable note plus a `violations` array of accepted entries:
+
+  ```json
+  {
+    "note": "TODO: fill in reason and willBeFixedIn for each entry before committing.",
+    "violations": [
+      {
+        "rule": "color-contrast",
+        "targets": ["#footer .legal"],
+        "reason": "TODO",
+        "willBeFixedIn": "TODO"
+      }
+    ]
+  }
+  ```
+
+  When you run a new test for the first time **locally**, the baseline file is auto-seeded next to where its snapshot would have been (e.g. `my-test-1.a11y-baseline.json` for WCAG, `my-test-1.a11y-baseline-best-practice.json` for best-practice). The first run passes; subsequent runs match against the file. Replace the `TODO` placeholders with a real reason and tracking ticket before committing.
+
+  When a test runs on **CI** (`process.env.CI` set) and would auto-seed a baseline file, the file is written and attached to the test report, but the test **fails** with a directive to download/commit it. This mirrors Playwright's default behaviour for missing visual snapshots and prevents new accessibility violations from silently slipping through CI.
+
+To force snapshot mode on a brand-new test, run it once with `--update-snapshots`; Playwright will create the snapshot file and from then on the test stays in snapshot mode.
+
+Existing tests that pass `baseline:` to `checkAccessibility()` (or `a11y.check()`) using `defineAccessibilityBaseline()` continue to work unchanged — explicit in-code baselines always take precedence over both snapshots and on-disk JSON files.
 
 ## Visual Comparisons for Static Content
 

--- a/src/util/accessibility-baseline-file.test.ts
+++ b/src/util/accessibility-baseline-file.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { promises as fs } from 'fs'
+import os from 'os'
+import path from 'path'
+import {
+  baselineFilePath,
+  buildSeed,
+  nextCallCount,
+  readBaselineFile,
+  resetCallCounts,
+  snapshotExists,
+  writeBaselineFile,
+} from './accessibility-baseline-file'
+
+function makeTestInfo(opts: { dir: string; title?: string; titlePath?: string[] }) {
+  const title = opts.title ?? 'standalone accessibility check works'
+  const titlePath = opts.titlePath ?? ['file.spec.ts', title]
+  return {
+    testId: `${title}-${Math.random()}`,
+    title,
+    titlePath,
+    snapshotPath: (name: string) => path.join(opts.dir, name + '.txt'),
+  }
+}
+
+describe('accessibility-baseline-file', () => {
+  let tmpDir: string
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'a11y-baseline-'))
+  })
+
+  afterEach(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true })
+  })
+
+  describe('baselineFilePath', () => {
+    it('builds a deterministic projectless path with counter and scan-kind suffix', () => {
+      const ti = makeTestInfo({ dir: tmpDir })
+      const wcag = baselineFilePath(ti, 'wcag', 1)
+      const bp = baselineFilePath(ti, 'best-practice', 1)
+      expect(wcag).toBe(path.join(tmpDir, 'standalone-accessibility-check-works-1.a11y-baseline.json'))
+      expect(bp).toBe(path.join(tmpDir, 'standalone-accessibility-check-works-1.a11y-baseline-best-practice.json'))
+    })
+
+    it('uses an incremented counter for multi-call tests', () => {
+      const ti = makeTestInfo({ dir: tmpDir })
+      const path2 = baselineFilePath(ti, 'wcag', 2)
+      expect(path2).toContain('-2.a11y-baseline.json')
+    })
+  })
+
+  describe('nextCallCount', () => {
+    it('returns sequential numbers per (testInfo, scan)', () => {
+      const ti = {} as any
+      try {
+        expect(nextCallCount(ti, 'wcag')).toBe(1)
+        expect(nextCallCount(ti, 'wcag')).toBe(2)
+        expect(nextCallCount(ti, 'best-practice')).toBe(1)
+        expect(nextCallCount(ti, 'wcag')).toBe(3)
+      } finally {
+        resetCallCounts(ti)
+      }
+    })
+  })
+
+  describe('snapshotExists', () => {
+    it('returns false when the snapshots dir is missing', async () => {
+      const ti = makeTestInfo({ dir: path.join(tmpDir, 'does-not-exist') })
+      expect(await snapshotExists(ti)).toBe(false)
+    })
+
+    it('returns false when no snapshot file matches the test slug', async () => {
+      await fs.writeFile(path.join(tmpDir, 'other-test-1-chromium-linux.txt'), 'data')
+      const ti = makeTestInfo({ dir: tmpDir })
+      expect(await snapshotExists(ti)).toBe(false)
+    })
+
+    it('returns true when a snapshot file matching the test slug exists', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'standalone-accessibility-check-works-1-chromium-linux.txt'),
+        'data',
+      )
+      const ti = makeTestInfo({ dir: tmpDir })
+      expect(await snapshotExists(ti)).toBe(true)
+    })
+  })
+
+  describe('readBaselineFile / writeBaselineFile', () => {
+    it('round-trips object schema with note and violations', async () => {
+      const file = path.join(tmpDir, 'rt.a11y-baseline.json')
+      await writeBaselineFile(file, {
+        note: 'No accessibility violations found',
+        violations: [],
+      })
+      const back = await readBaselineFile(file)
+      expect(back).toEqual({ note: 'No accessibility violations found', violations: [] })
+    })
+
+    it('returns null when file is missing', async () => {
+      const file = path.join(tmpDir, 'missing.json')
+      expect(await readBaselineFile(file)).toBeNull()
+    })
+
+    it('does not throw on EEXIST (idempotent first-write)', async () => {
+      const file = path.join(tmpDir, 'idem.json')
+      await writeBaselineFile(file, { note: 'first', violations: [] })
+      await writeBaselineFile(file, { note: 'second', violations: [] })
+      const back = await readBaselineFile(file)
+      expect(back?.note).toBe('first')
+    })
+
+    it('throws a clear error on malformed JSON', async () => {
+      const file = path.join(tmpDir, 'bad.json')
+      await fs.writeFile(file, '{not json')
+      await expect(readBaselineFile(file)).rejects.toThrow(/Malformed baseline file/)
+    })
+
+    it('creates parent directories on write', async () => {
+      const file = path.join(tmpDir, 'nested', 'sub', 'baseline.json')
+      await writeBaselineFile(file, { note: 'x', violations: [] })
+      expect((await readBaselineFile(file))?.note).toBe('x')
+    })
+  })
+
+  describe('buildSeed', () => {
+    it('produces a clean-state payload for zero violations', () => {
+      expect(buildSeed([])).toEqual({
+        note: 'No accessibility violations found',
+        violations: [],
+      })
+    })
+
+    it('produces a TODO-prompted payload for non-zero violations', () => {
+      const v = [{ rule: 'color-contrast', targets: ['#x'], reason: 'TODO', willBeFixedIn: 'TODO' }]
+      const seed = buildSeed(v)
+      expect(seed.note).toMatch(/TODO/)
+      expect(seed.violations).toEqual(v)
+    })
+  })
+})

--- a/src/util/accessibility-baseline-file.test.ts
+++ b/src/util/accessibility-baseline-file.test.ts
@@ -5,9 +5,9 @@ import path from 'path'
 import {
   baselineFilePath,
   buildSeed,
-  nextCallCount,
+  nextAccessibilityScanCount,
   readBaselineFile,
-  resetCallCounts,
+  resetAccessibilityScanCounts,
   snapshotExists,
   writeBaselineFile,
 } from './accessibility-baseline-file'
@@ -19,7 +19,7 @@ function makeTestInfo(opts: { dir: string; title?: string; titlePath?: string[] 
     testId: `${title}-${Math.random()}`,
     title,
     titlePath,
-    snapshotPath: (name: string) => path.join(opts.dir, name + '.txt'),
+    snapshotPath: (...segs: string[]) => path.join(opts.dir, ...segs),
   }
 }
 
@@ -50,16 +50,16 @@ describe('accessibility-baseline-file', () => {
     })
   })
 
-  describe('nextCallCount', () => {
+  describe('nextAccessibilityScanCount', () => {
     it('returns sequential numbers per (testInfo, scan)', () => {
       const ti = {} as any
       try {
-        expect(nextCallCount(ti, 'wcag')).toBe(1)
-        expect(nextCallCount(ti, 'wcag')).toBe(2)
-        expect(nextCallCount(ti, 'best-practice')).toBe(1)
-        expect(nextCallCount(ti, 'wcag')).toBe(3)
+        expect(nextAccessibilityScanCount(ti, 'wcag')).toBe(1)
+        expect(nextAccessibilityScanCount(ti, 'wcag')).toBe(2)
+        expect(nextAccessibilityScanCount(ti, 'best-practice')).toBe(1)
+        expect(nextAccessibilityScanCount(ti, 'wcag')).toBe(3)
       } finally {
-        resetCallCounts(ti)
+        resetAccessibilityScanCounts(ti)
       }
     })
   })

--- a/src/util/accessibility-baseline-file.ts
+++ b/src/util/accessibility-baseline-file.ts
@@ -10,31 +10,52 @@ export interface OnDiskBaselineFile {
   violations: AccessibilityBaselineEntry[]
 }
 
-const callCounters = new WeakMap<object, Map<ScanKind, number>>()
+const scanInvocationCounters = new WeakMap<object, Map<ScanKind, number>>()
 
-export function nextCallCount(testInfo: Pick<TestInfo, 'testId'> | object, scan: ScanKind): number {
+/**
+ * Increment and return the 1-indexed invocation number for this scan kind
+ * within the current test. Every call to `checkAccessibility()` runs up to
+ * two scans (WCAG + best-practice); each scan gets its own counter so that
+ * a test calling `checkAccessibility()` twice produces distinct baseline
+ * file names (`…-1.a11y-baseline.json`, `…-2.a11y-baseline.json`) even when
+ * both scans share a single `checkAccessibility()` call.
+ *
+ * Counter state is keyed by the TestInfo object (held in a WeakMap so it
+ * is discarded with the test). Use `resetAccessibilityScanCounts()` to
+ * clear state explicitly — for example, between tests in a unit-test
+ * suite that reuses a mocked TestInfo.
+ */
+export function nextAccessibilityScanCount(
+  testInfo: Pick<TestInfo, 'testId'> | object,
+  scan: ScanKind,
+): number {
   const key = testInfo as object
-  let counts = callCounters.get(key)
+  let counts = scanInvocationCounters.get(key)
   if (!counts) {
     counts = new Map()
-    callCounters.set(key, counts)
+    scanInvocationCounters.set(key, counts)
   }
   const n = (counts.get(scan) ?? 0) + 1
   counts.set(scan, n)
   return n
 }
 
-export function resetCallCounts(testInfo: object): void {
-  callCounters.delete(testInfo)
+export function resetAccessibilityScanCounts(testInfo: object): void {
+  scanInvocationCounters.delete(testInfo)
 }
 
+/**
+ * Slugify a test's fully qualified title the same way we use it as the
+ * stem of both on-disk baseline filenames and (for existence checks) the
+ * prefix of Playwright's auto-generated snapshot filenames.
+ *
+ * Implemented as a single-pass character scan to avoid regex-based
+ * polynomial backtracking on library-supplied input (CodeQL
+ * js/polynomial-redos).
+ */
 function slugifyTitle(testInfo: Pick<TestInfo, 'titlePath' | 'title'>): string {
   const segments = testInfo.titlePath?.slice(1) ?? []
   const raw = segments.length > 0 ? segments.join(' ') : testInfo.title
-  // Manual slugify — replaces runs of non-alphanumerics with a single '-' and
-  // trims leading/trailing hyphens. Implemented as a single pass over the
-  // string to avoid regex-based polynomial backtracking on library-supplied
-  // input (CodeQL js/polynomial-redos).
   let out = ''
   let lastWasHyphen = true // suppresses leading hyphen
   for (let i = 0; i < raw.length; i++) {
@@ -58,26 +79,40 @@ function slugifyTitle(testInfo: Pick<TestInfo, 'titlePath' | 'title'>): string {
   return out
 }
 
-function snapshotsDir(testInfo: Pick<TestInfo, 'snapshotPath'>): string {
-  const probe = testInfo.snapshotPath('a11y-baseline-probe')
-  return path.dirname(probe)
-}
-
+/**
+ * Build the on-disk baseline file path for a single scan call.
+ *
+ * Playwright exposes `testInfo.snapshotPath(...name)` as the public way to
+ * resolve a file under the test's snapshots directory (honoring any
+ * user-configured `snapshotPathTemplate`). We pass a filename that mixes
+ * the slugified test title + call counter + a scan-specific suffix, so two
+ * different tests in the same spec file don't collide and each scan has
+ * its own file.
+ *
+ * There is no reusable Playwright API that bakes the test title into an
+ * explicit-name snapshot path — that logic is private to `toMatchSnapshot()`
+ * for its auto-counter naming — so we build the stem ourselves.
+ */
 export function baselineFilePath(
   testInfo: Pick<TestInfo, 'snapshotPath' | 'titlePath' | 'title'>,
   scan: ScanKind,
   callCount: number,
 ): string {
-  const dir = snapshotsDir(testInfo)
   const slug = slugifyTitle(testInfo)
   const suffix = scan === 'wcag' ? 'a11y-baseline' : 'a11y-baseline-best-practice'
-  return path.join(dir, `${slug}-${callCount}.${suffix}.json`)
+  return testInfo.snapshotPath(`${slug}-${callCount}.${suffix}.json`)
 }
 
+/**
+ * Return true if a Playwright snapshot file already exists on disk for
+ * this test — i.e. the test has been previously committed under snapshot
+ * mode. Used to preserve snapshot-mode behaviour for existing tests while
+ * defaulting new (snapshotless) tests into on-disk baseline mode.
+ */
 export async function snapshotExists(
   testInfo: Pick<TestInfo, 'snapshotPath' | 'titlePath' | 'title'>,
 ): Promise<boolean> {
-  const dir = snapshotsDir(testInfo)
+  const dir = path.dirname(testInfo.snapshotPath('a11y-baseline-probe'))
   let entries: string[]
   try {
     entries = await fs.readdir(dir)

--- a/src/util/accessibility-baseline-file.ts
+++ b/src/util/accessibility-baseline-file.ts
@@ -31,7 +31,31 @@ export function resetCallCounts(testInfo: object): void {
 function slugifyTitle(testInfo: Pick<TestInfo, 'titlePath' | 'title'>): string {
   const segments = testInfo.titlePath?.slice(1) ?? []
   const raw = segments.length > 0 ? segments.join(' ') : testInfo.title
-  return raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+  // Manual slugify — replaces runs of non-alphanumerics with a single '-' and
+  // trims leading/trailing hyphens. Implemented as a single pass over the
+  // string to avoid regex-based polynomial backtracking on library-supplied
+  // input (CodeQL js/polynomial-redos).
+  let out = ''
+  let lastWasHyphen = true // suppresses leading hyphen
+  for (let i = 0; i < raw.length; i++) {
+    const code = raw.charCodeAt(i)
+    const isLowerAlpha = code >= 97 && code <= 122 // a-z
+    const isUpperAlpha = code >= 65 && code <= 90 // A-Z
+    const isDigit = code >= 48 && code <= 57 // 0-9
+    if (isLowerAlpha || isDigit) {
+      out += raw[i]
+      lastWasHyphen = false
+    } else if (isUpperAlpha) {
+      out += String.fromCharCode(code + 32)
+      lastWasHyphen = false
+    } else if (!lastWasHyphen) {
+      out += '-'
+      lastWasHyphen = true
+    }
+  }
+  // Trim trailing hyphen.
+  if (out.endsWith('-')) out = out.slice(0, -1)
+  return out
 }
 
 function snapshotsDir(testInfo: Pick<TestInfo, 'snapshotPath'>): string {

--- a/src/util/accessibility-baseline-file.ts
+++ b/src/util/accessibility-baseline-file.ts
@@ -1,0 +1,108 @@
+import { promises as fs } from 'fs'
+import path from 'path'
+import type { TestInfo } from '@playwright/test'
+import type { AccessibilityBaselineEntry } from './accessibility-baseline'
+
+export type ScanKind = 'wcag' | 'best-practice'
+
+export interface OnDiskBaselineFile {
+  note: string
+  violations: AccessibilityBaselineEntry[]
+}
+
+const callCounters = new WeakMap<object, Map<ScanKind, number>>()
+
+export function nextCallCount(testInfo: Pick<TestInfo, 'testId'> | object, scan: ScanKind): number {
+  const key = testInfo as object
+  let counts = callCounters.get(key)
+  if (!counts) {
+    counts = new Map()
+    callCounters.set(key, counts)
+  }
+  const n = (counts.get(scan) ?? 0) + 1
+  counts.set(scan, n)
+  return n
+}
+
+export function resetCallCounts(testInfo: object): void {
+  callCounters.delete(testInfo)
+}
+
+function slugifyTitle(testInfo: Pick<TestInfo, 'titlePath' | 'title'>): string {
+  const segments = testInfo.titlePath?.slice(1) ?? []
+  const raw = segments.length > 0 ? segments.join(' ') : testInfo.title
+  return raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '')
+}
+
+function snapshotsDir(testInfo: Pick<TestInfo, 'snapshotPath'>): string {
+  const probe = testInfo.snapshotPath('a11y-baseline-probe')
+  return path.dirname(probe)
+}
+
+export function baselineFilePath(
+  testInfo: Pick<TestInfo, 'snapshotPath' | 'titlePath' | 'title'>,
+  scan: ScanKind,
+  callCount: number,
+): string {
+  const dir = snapshotsDir(testInfo)
+  const slug = slugifyTitle(testInfo)
+  const suffix = scan === 'wcag' ? 'a11y-baseline' : 'a11y-baseline-best-practice'
+  return path.join(dir, `${slug}-${callCount}.${suffix}.json`)
+}
+
+export async function snapshotExists(
+  testInfo: Pick<TestInfo, 'snapshotPath' | 'titlePath' | 'title'>,
+): Promise<boolean> {
+  const dir = snapshotsDir(testInfo)
+  let entries: string[]
+  try {
+    entries = await fs.readdir(dir)
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return false
+    throw err
+  }
+  const slug = slugifyTitle(testInfo)
+  return entries.some(name => name.startsWith(`${slug}-`) && name.endsWith('.txt'))
+}
+
+export async function readBaselineFile(filePath: string): Promise<OnDiskBaselineFile | null> {
+  let raw: string
+  try {
+    raw = await fs.readFile(filePath, 'utf8')
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null
+    throw err
+  }
+  try {
+    const parsed = JSON.parse(raw)
+    if (!parsed || typeof parsed !== 'object' || !Array.isArray(parsed.violations)) {
+      throw new Error('expected an object with a "violations" array')
+    }
+    return {
+      note: typeof parsed.note === 'string' ? parsed.note : '',
+      violations: parsed.violations as AccessibilityBaselineEntry[],
+    }
+  } catch (err) {
+    throw new Error(`Malformed baseline file at ${filePath}: ${(err as Error).message}`)
+  }
+}
+
+export async function writeBaselineFile(filePath: string, data: OnDiskBaselineFile): Promise<void> {
+  await fs.mkdir(path.dirname(filePath), { recursive: true })
+  try {
+    await fs.writeFile(filePath, JSON.stringify(data, null, 2) + '\n', { flag: 'wx' })
+  } catch (err: any) {
+    if (err?.code === 'EEXIST') return
+    throw err
+  }
+}
+
+export function buildSeed(violations: AccessibilityBaselineEntry[]): OnDiskBaselineFile {
+  if (violations.length === 0) {
+    return { note: 'No accessibility violations found', violations: [] }
+  }
+  return {
+    note: 'TODO: fill in reason and willBeFixedIn for each entry before committing.',
+    violations,
+  }
+}

--- a/src/util/accessibility-baseline.test.ts
+++ b/src/util/accessibility-baseline.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
 // Mock AxeBuilder — must be hoisted since vi.mock is hoisted
 const { mockWithTags, mockExclude, mockOptions, mockAnalyze, MockAxeBuilder } = vi.hoisted(() => {
@@ -62,10 +62,21 @@ function makeAxeResults(overrides?: Partial<{ violations: any[], passes: any[] }
   }
 }
 
-function makeTestInfo() {
+function makeTestInfo(opts?: { updateSnapshots?: 'all' | 'changed' | 'missing' | 'none', snapshotsDir?: string, title?: string }) {
+  // Default to `updateSnapshots: 'all'` so that, in the absence of an
+  // explicit `baseline` option, the dispatch routes to snapshot mode (the
+  // legacy behavior these tests were originally written against). Tests
+  // that want to exercise on-disk baseline mode override this.
+  const dir = opts?.snapshotsDir ?? '/tmp/__a11y_test_snapshots__'
+  const title = opts?.title ?? 'mocked test'
   return {
+    testId: `mocked-${Math.random()}`,
+    title,
+    titlePath: ['file.spec.ts', title],
     annotations: [] as Array<{ type: string, description?: string }>,
     attach: vi.fn().mockResolvedValue(undefined),
+    snapshotPath: (...segs: string[]) => `${dir}/${segs.join('/')}.txt`,
+    config: { updateSnapshots: opts?.updateSnapshots ?? 'all' },
   }
 }
 
@@ -369,6 +380,153 @@ describe('accessibility baseline', () => {
         'a11y-baseline-suggestions',
         expect.anything()
       )
+    })
+  })
+
+  describe('on-disk baseline (new default for snapshotless tests)', () => {
+    let tmpDir: string
+    let originalCI: string | undefined
+
+    beforeEach(async () => {
+      const fs = await import('fs')
+      const os = await import('os')
+      const path = await import('path')
+      tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'a11y-disp-'))
+      originalCI = process.env.CI
+      delete process.env.CI
+    })
+
+    afterEach(async () => {
+      const fs = await import('fs')
+      await fs.promises.rm(tmpDir, { recursive: true, force: true })
+      if (originalCI === undefined) delete process.env.CI
+      else process.env.CI = originalCI
+    })
+
+    it('seeds an empty baseline file when no violations and no snapshot exist (local)', async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({ violations: [] }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'none', snapshotsDir: tmpDir, title: 'clean test' })
+      await checkAccessibility(makePage() as any, testInfo as any, {
+        bestPracticeMode: 'off',
+      })
+
+      const fs = await import('fs')
+      const path = await import('path')
+      const file = path.join(tmpDir, 'clean-test-1.a11y-baseline.json')
+      const written = JSON.parse(await fs.promises.readFile(file, 'utf8'))
+      expect(written.note).toBe('No accessibility violations found')
+      expect(written.violations).toEqual([])
+
+      // Snapshot mode is NOT used; on-disk baseline mode used assertBaseline.
+      expect(mockToMatchSnapshot).not.toHaveBeenCalled()
+      // Test does not fail (no toBe call against a "baseline file present" sentinel).
+      expect(mockToBe).not.toHaveBeenCalled()
+    })
+
+    it('seeds a TODO-prompted baseline file when violations exist and no snapshot (local)', async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({
+        violations: [makeViolation('color-contrast', [['#footer .legal']])],
+      }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'none', snapshotsDir: tmpDir, title: 'with violations' })
+      await checkAccessibility(makePage() as any, testInfo as any, {
+        bestPracticeMode: 'off',
+      })
+
+      const fs = await import('fs')
+      const path = await import('path')
+      const file = path.join(tmpDir, 'with-violations-1.a11y-baseline.json')
+      const written = JSON.parse(await fs.promises.readFile(file, 'utf8'))
+      expect(written.note).toMatch(/TODO/)
+      expect(written.violations).toEqual([
+        { rule: 'color-contrast', targets: ['#footer .legal'], reason: 'TODO', willBeFixedIn: 'TODO' },
+      ])
+      expect(mockToBe).not.toHaveBeenCalled()
+    })
+
+    it('fails the test on CI when seeding (mirrors Playwright missing-snapshot behaviour)', async () => {
+      process.env.CI = '1'
+      mockAnalyze.mockResolvedValue(makeAxeResults({
+        violations: [makeViolation('color-contrast', [['#x']])],
+      }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'none', snapshotsDir: tmpDir, title: 'on ci' })
+      await checkAccessibility(makePage() as any, testInfo as any, {
+        bestPracticeMode: 'off',
+      })
+
+      // File is still seeded.
+      const fs = await import('fs')
+      const path = await import('path')
+      const file = path.join(tmpDir, 'on-ci-1.a11y-baseline.json')
+      expect(fs.existsSync(file)).toBe(true)
+
+      // Test fails with the seed-and-commit directive.
+      expect(mockToBe).toHaveBeenCalled()
+      const failureMessage = mockExpectHard.mock.calls.find(
+        (call: any[]) => call.length >= 2 && typeof call[1] === 'string' && call[1].includes('a11y baseline file was missing')
+      )?.[1] as string
+      expect(failureMessage).toContain(file)
+      expect(failureMessage).toMatch(/commit it/i)
+    })
+
+    it('loads an existing on-disk baseline JSON and matches violations against it', async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({
+        violations: [makeViolation('color-contrast', [['#known']])],
+      }))
+
+      // Pre-write a baseline.
+      const fs = await import('fs')
+      const path = await import('path')
+      const file = path.join(tmpDir, 'known-test-1.a11y-baseline.json')
+      await fs.promises.writeFile(file, JSON.stringify({
+        note: 'Known issue tracked in PROJ-1.',
+        violations: [{ rule: 'color-contrast', targets: ['#known'], reason: 'Known', willBeFixedIn: 'PROJ-1' }],
+      }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'none', snapshotsDir: tmpDir, title: 'known test' })
+      await checkAccessibility(makePage() as any, testInfo as any, {
+        bestPracticeMode: 'off',
+      })
+
+      // Violation matched -> no failure.
+      expect(mockToBe).not.toHaveBeenCalled()
+      const baselined = testInfo.annotations.filter(a => a.type === 'Baselined a11y violation')
+      expect(baselined).toHaveLength(1)
+    })
+
+    it('produces per-call counter files for multi-call tests', async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({ violations: [] }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'none', snapshotsDir: tmpDir, title: 'multi call' })
+      await checkAccessibility(makePage() as any, testInfo as any, { bestPracticeMode: 'off' })
+      await checkAccessibility(makePage() as any, testInfo as any, { bestPracticeMode: 'off' })
+
+      const fs = await import('fs')
+      const path = await import('path')
+      const f1 = path.join(tmpDir, 'multi-call-1.a11y-baseline.json')
+      const f2 = path.join(tmpDir, 'multi-call-2.a11y-baseline.json')
+      expect(fs.existsSync(f1)).toBe(true)
+      expect(fs.existsSync(f2)).toBe(true)
+    })
+
+    it('still uses snapshot mode when a legacy snapshot file exists for the test', async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({ violations: [] }))
+
+      // Pre-create a Playwright-style snapshot file in the snapshots dir.
+      const fs = await import('fs')
+      const path = await import('path')
+      await fs.promises.writeFile(
+        path.join(tmpDir, 'legacy-test-1-chromium-linux.txt'),
+        '[]\n',
+      )
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'none', snapshotsDir: tmpDir, title: 'legacy test' })
+      await checkAccessibility(makePage() as any, testInfo as any, { bestPracticeMode: 'off' })
+
+      // Snapshot mode -> toMatchSnapshot was invoked.
+      expect(mockToMatchSnapshot).toHaveBeenCalled()
     })
   })
 })

--- a/src/util/accessibility-baseline.test.ts
+++ b/src/util/accessibility-baseline.test.ts
@@ -75,7 +75,7 @@ function makeTestInfo(opts?: { updateSnapshots?: 'all' | 'changed' | 'missing' |
     titlePath: ['file.spec.ts', title],
     annotations: [] as Array<{ type: string, description?: string }>,
     attach: vi.fn().mockResolvedValue(undefined),
-    snapshotPath: (...segs: string[]) => `${dir}/${segs.join('/')}.txt`,
+    snapshotPath: (...segs: string[]) => `${dir}/${segs.join('/')}`,
     config: { updateSnapshots: opts?.updateSnapshots ?? 'all' },
   }
 }

--- a/src/util/accessible-screenshot.test.ts
+++ b/src/util/accessible-screenshot.test.ts
@@ -61,8 +61,13 @@ function makeAxeResults(overrides?: Partial<{ violations: any[], passes: any[] }
 
 function makeTestInfo() {
   return {
+    testId: `mocked-${Math.random()}`,
+    title: 'mocked test',
+    titlePath: ['file.spec.ts', 'mocked test'],
     annotations: [] as Array<{ type: string, description?: string }>,
     attach: vi.fn().mockResolvedValue(undefined),
+    snapshotPath: (...segs: string[]) => `/tmp/__a11y_test_snapshots__/${segs.join('/')}.txt`,
+    config: { updateSnapshots: 'all' as const },
   }
 }
 

--- a/src/util/accessible-screenshot.test.ts
+++ b/src/util/accessible-screenshot.test.ts
@@ -66,7 +66,7 @@ function makeTestInfo() {
     titlePath: ['file.spec.ts', 'mocked test'],
     annotations: [] as Array<{ type: string, description?: string }>,
     attach: vi.fn().mockResolvedValue(undefined),
-    snapshotPath: (...segs: string[]) => `/tmp/__a11y_test_snapshots__/${segs.join('/')}.txt`,
+    snapshotPath: (...segs: string[]) => `/tmp/__a11y_test_snapshots__/${segs.join('/')}`,
     config: { updateSnapshots: 'all' as const },
   }
 }

--- a/src/util/accessible-screenshot.ts
+++ b/src/util/accessible-screenshot.ts
@@ -3,7 +3,16 @@ import {expect, Locator, Page, TestInfo} from "@playwright/test";
 import {waitForAllImages} from "./images";
 import {waitForFrames} from "./frames"
 import axe from 'axe-core';
-import {AccessibilityBaseline} from './accessibility-baseline'
+import {AccessibilityBaseline, AccessibilityBaselineEntry} from './accessibility-baseline'
+import {
+  baselineFilePath,
+  buildSeed,
+  nextCallCount,
+  readBaselineFile,
+  ScanKind,
+  snapshotExists,
+  writeBaselineFile,
+} from './accessibility-baseline-file'
 
 let a11yActionHintShown = false;
 
@@ -151,7 +160,17 @@ export async function checkAccessibility(page: Page, testInfo: TestInfo, options
   }
 
   if (bestPracticeMode !== 'off') {
-    await runBestPracticeScan(page, testInfo, { exclude, rules, disableDefaultExclusions, bestPracticeMode })
+    const bpResults = await runBestPracticeScan(page, testInfo, { exclude, rules, disableDefaultExclusions })
+    // Best-practice always uses expect.soft() so the WCAG scan below runs
+    // even when best-practice violations exist. `bestPracticeMode === 'hard'`
+    // is preserved as a marker but does not change soft-vs-hard here.
+    await dispatchAssertion({
+      testInfo,
+      results: bpResults,
+      scan: 'best-practice',
+      expectFn: expect.soft,
+      scanLabel: 'Best-practice scan',
+    }, baseline)
   }
 
   const wcagScanResults = await runWcagScan(page, testInfo, { wcagTags, exclude, rules, disableDefaultExclusions })
@@ -160,21 +179,93 @@ export async function checkAccessibility(page: Page, testInfo: TestInfo, options
     await screenshotViolatingElements(page, testInfo, wcagScanResults)
   }
 
-  // Baseline mode: match violations against the baseline instead of using snapshots.
-  if (baseline) {
-    return assertBaseline(testInfo, wcagScanResults, baseline)
-  }
+  await dispatchAssertion({
+    testInfo,
+    results: wcagScanResults,
+    scan: 'wcag',
+    expectFn: expect,
+    scanLabel: 'WCAG scan',
+  }, baseline)
+}
 
-  // Snapshot mode (no baseline).
-  return assertSnapshot(testInfo, wcagScanResults)
+interface ScanContext {
+  testInfo: TestInfo
+  results: axe.AxeResults
+  scan: ScanKind
+  expectFn: typeof expect | typeof expect.soft
+  scanLabel: string
 }
 
 /**
- * Run the best-practice axe scan and assert on violations via snapshot.
+ * Dispatch the assertion for one scan to the correct mode:
  *
- * Always uses expect.soft() so the WCAG scan runs regardless of failures.
- * When bestPracticeMode is 'hard', failures still mark the test as failed
- * (that's what expect.soft() does) but execution continues.
+ * 1. Explicit in-code `baseline` option -> baseline mode (existing behaviour).
+ * 2. A snapshot file already exists on disk for this test -> snapshot mode
+ *    (existing behaviour, preserves all previously committed snapshots).
+ * 3. Playwright is in snapshot-update mode (`all`/`changed`/`missing`) ->
+ *    snapshot mode (Playwright will create the snapshot).
+ * 4. Otherwise -> on-disk baseline mode. If the JSON file exists, load and
+ *    match against it. If it does not, seed it. On CI seeding fails the
+ *    test (matching Playwright's missing-snapshot behaviour); locally,
+ *    seeding passes so the first run is green.
+ */
+async function dispatchAssertion(ctx: ScanContext, inCodeBaseline?: AccessibilityBaseline): Promise<void> {
+  if (inCodeBaseline) {
+    return assertBaseline(ctx, inCodeBaseline)
+  }
+
+  if (await snapshotExists(ctx.testInfo)) {
+    return assertSnapshot(ctx)
+  }
+
+  const update = ctx.testInfo.config?.updateSnapshots
+  if (update === 'all' || update === 'changed' || update === 'missing') {
+    return assertSnapshot(ctx)
+  }
+
+  const callCount = nextCallCount(ctx.testInfo, ctx.scan)
+  const filePath = baselineFilePath(ctx.testInfo, ctx.scan, callCount)
+
+  const existing = await readBaselineFile(filePath)
+  if (existing) {
+    return assertBaseline(ctx, existing.violations)
+  }
+
+  // Seed and either pass (local) or fail (CI).
+  const normalized = extractNormalizedViolations(ctx.results)
+  const seedViolations: AccessibilityBaselineEntry[] = normalized.map(v => ({
+    rule: v.rule,
+    targets: v.targets,
+    reason: 'TODO',
+    willBeFixedIn: 'TODO',
+  }))
+  const seed = buildSeed(seedViolations)
+  await writeBaselineFile(filePath, seed)
+  await ctx.testInfo.attach(`a11y-${ctx.scan}-baseline-seed`, {
+    path: filePath,
+    contentType: 'application/json',
+  })
+
+  if (process.env.CI) {
+    const message = `${ctx.scanLabel}: a11y baseline file was missing for this test. Seeded to ${filePath} — download the attached file from CI artifacts (or re-run locally) and commit it before merging.`
+    ctx.expectFn(null, message).toBe('a11y baseline file present')
+    return
+  }
+
+  ctx.testInfo.annotations.push({
+    type: 'Accessibility',
+    description: seed.violations.length === 0
+      ? `${ctx.scanLabel}: a11y baseline seeded at ${filePath} (no violations).`
+      : `${ctx.scanLabel}: a11y baseline seeded at ${filePath} with ${seed.violations.length} entries — fill in reason/willBeFixedIn before committing.`,
+  })
+  return assertBaseline(ctx, seed.violations)
+}
+
+/**
+ * Run the best-practice axe scan, attach results, and return them for
+ * dispatch. The assertion (snapshot vs baseline) is decided by the
+ * dispatcher based on what's already on disk and the `bestPracticeMode`
+ * option drives soft- vs hard-failure behaviour.
  */
 async function runBestPracticeScan(
   page: Page,
@@ -183,9 +274,8 @@ async function runBestPracticeScan(
     exclude: string[]
     rules?: Record<string, { enabled: boolean }>
     disableDefaultExclusions: boolean
-    bestPracticeMode: 'soft' | 'hard'
   },
-) {
+): Promise<axe.AxeResults> {
   const builder = new AxeBuilder({ page })
     .withTags(['best-practice'])
 
@@ -222,9 +312,7 @@ async function runBestPracticeScan(
     description: `Best-practice scan: ${results.violations.length} violations (${results.passes.length} rules passed)`
   })
 
-  // Always use expect.soft() so the WCAG scan below runs even if
-  // best-practice violations are found.
-  expect.soft(violationFingerprints(results)).toMatchSnapshot()
+  return results
 }
 
 /**
@@ -304,10 +392,11 @@ async function screenshotViolatingElements(page: Page, testInfo: TestInfo, resul
 }
 
 /**
- * Assert WCAG violations against a baseline allowlist.
+ * Assert violations against a baseline allowlist (in-code or on-disk).
  */
-function assertBaseline(testInfo: TestInfo, wcagScanResults: axe.AxeResults, baseline: AccessibilityBaseline) {
-  const allViolations = extractNormalizedViolations(wcagScanResults)
+function assertBaseline(ctx: ScanContext, baseline: AccessibilityBaseline) {
+  const { testInfo, results, scanLabel, expectFn } = ctx
+  const allViolations = extractNormalizedViolations(results)
   const matchedBaselineIndices = new Set<number>()
   const unmatchedViolations: typeof allViolations = []
 
@@ -346,40 +435,46 @@ function assertBaseline(testInfo: TestInfo, wcagScanResults: axe.AxeResults, bas
   const baselinedCount = matchedBaselineIndices.size
   testInfo.annotations.push({
     type: 'Accessibility',
-    description: `WCAG scan: ${unmatchedViolations.length} new violations (${baselinedCount} baselined)`,
+    description: `${scanLabel}: ${unmatchedViolations.length} new violations (${baselinedCount} baselined)`,
   })
 
   // Fail on unmatched violations with detailed output.
   if (unmatchedViolations.length > 0) {
-    const details = formatViolationDetails(wcagScanResults, unmatchedViolations)
-    expect(null, details).toBe('no accessibility violations')
+    const details = formatViolationDetails(results, unmatchedViolations)
+    expectFn(null, details).toBe('no accessibility violations')
   }
 }
 
 /**
- * Assert WCAG violations via snapshot comparison (default mode).
+ * Assert via snapshot comparison (legacy mode for tests with committed snapshots).
  */
-async function assertSnapshot(testInfo: TestInfo, wcagScanResults: axe.AxeResults) {
-  testInfo.annotations.push({
-    type: 'Accessibility',
-    description: `WCAG scan: ${wcagScanResults.violations.length} violations (${wcagScanResults.passes.length} rules passed)`
-  })
+async function assertSnapshot(ctx: ScanContext) {
+  const { testInfo, results, scan, expectFn } = ctx
 
-  // If there are violations, attach baseline suggestions and push annotation.
-  if (wcagScanResults.violations.length > 0) {
-    const allViolations = extractNormalizedViolations(wcagScanResults)
-    const suggestions = allViolations.map(v => formatBaselineSuggestion(v)).join('\n')
-    await testInfo.attach('a11y-baseline-suggestions', {
-      body: suggestions,
-      contentType: 'text/plain',
-    })
+  // Match the legacy summary annotation phrasing for WCAG; best-practice's
+  // pre-existing summary annotation is emitted in runBestPracticeScan.
+  if (scan === 'wcag') {
     testInfo.annotations.push({
       type: 'Accessibility',
-      description: 'To manage violations explicitly, switch to baseline mode. See a11y-baseline-suggestions attachment.',
+      description: `WCAG scan: ${results.violations.length} violations (${results.passes.length} rules passed)`
     })
+
+    // If there are violations, attach baseline suggestions and push annotation.
+    if (results.violations.length > 0) {
+      const allViolations = extractNormalizedViolations(results)
+      const suggestions = allViolations.map(v => formatBaselineSuggestion(v)).join('\n')
+      await testInfo.attach('a11y-baseline-suggestions', {
+        body: suggestions,
+        contentType: 'text/plain',
+      })
+      testInfo.annotations.push({
+        type: 'Accessibility',
+        description: 'To manage violations explicitly, switch to baseline mode. See a11y-baseline-suggestions attachment.',
+      })
+    }
   }
 
-  return expect(violationFingerprints(wcagScanResults)).toMatchSnapshot()
+  return expectFn(violationFingerprints(results)).toMatchSnapshot()
 }
 
 /**

--- a/src/util/accessible-screenshot.ts
+++ b/src/util/accessible-screenshot.ts
@@ -7,7 +7,7 @@ import {AccessibilityBaseline, AccessibilityBaselineEntry} from './accessibility
 import {
   baselineFilePath,
   buildSeed,
-  nextCallCount,
+  nextAccessibilityScanCount,
   readBaselineFile,
   ScanKind,
   snapshotExists,
@@ -223,7 +223,7 @@ async function dispatchAssertion(ctx: ScanContext, inCodeBaseline?: Accessibilit
     return assertSnapshot(ctx)
   }
 
-  const callCount = nextCallCount(ctx.testInfo, ctx.scan)
+  const callCount = nextAccessibilityScanCount(ctx.testInfo, ctx.scan)
   const filePath = baselineFilePath(ctx.testInfo, ctx.scan, callCount)
 
   const existing = await readBaselineFile(filePath)


### PR DESCRIPTION
## Summary
- New a11y tests default to **baseline mode** (on-disk JSON file colocated with snapshots); existing tests with committed snapshots are unchanged.
- Baseline file uses an object schema: `{ "note": string, "violations": AccessibilityBaselineEntry[] }`. Per-test, per-call counter; one file per test across browsers.
- On **CI**, missing baselines are seeded *and* the test fails with a directive to commit the file — mirrors Playwright's default for missing visual snapshots so regressions can't slip through.
- Best-practice scan participates in the same dispatch with its own `*.a11y-baseline-best-practice.json` file.
- Explicit `options.baseline` (in-code via `defineAccessibilityBaseline()`) still takes precedence over both snapshots and on-disk files.

## Migration
- Existing snapshot-mode tests: nothing to do.
- New test wants snapshot mode? Run once with `--update-snapshots`.
- New test with violations: run locally; the JSON baseline is auto-seeded with `TODO` placeholders. Fill them in before committing.

## Test plan
- [x] All existing unit tests pass (117 → 123 with new dispatch coverage).
- [x] `tsc --noEmit` clean.
- [x] Local bats integration suite green via husky pre-commit hook (`CLAUDECODE` path).
- [ ] CI: lint, type-check, unit, integration, docs build.
- [ ] Snapshotless test on local seeds JSON and passes.
- [ ] Snapshotless test on CI seeds JSON, attaches it, and fails with seed-and-commit directive.
- [ ] Multi-call test produces per-counter files.
- [ ] Best-practice scan uses its own baseline file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)