### PR TITLE
fix(a11y): treat 'missing' as baseline mode, not snapshot mode

### DIFF
--- a/src/util/accessibility-baseline.test.ts
+++ b/src/util/accessibility-baseline.test.ts
@@ -528,5 +528,39 @@ describe('accessibility baseline', () => {
       // Snapshot mode -> toMatchSnapshot was invoked.
       expect(mockToMatchSnapshot).toHaveBeenCalled()
     })
+
+    it("uses on-disk baseline mode when updateSnapshots is 'missing' (Playwright's default)", async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({ violations: [] }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'missing', snapshotsDir: tmpDir, title: 'default config' })
+      await checkAccessibility(makePage() as any, testInfo as any, { bestPracticeMode: 'off' })
+
+      // Playwright's default config value is 'missing' — not an explicit user
+      // opt-in via --update-snapshots. It must route to baseline mode so new
+      // a11y tests default to baseline mode as documented.
+      const fs = await import('fs')
+      const path = await import('path')
+      const file = path.join(tmpDir, 'default-config-1.a11y-baseline.json')
+      expect(fs.existsSync(file)).toBe(true)
+      expect(mockToMatchSnapshot).not.toHaveBeenCalled()
+    })
+
+    it("uses snapshot mode when updateSnapshots is 'changed' (explicit --update-snapshots)", async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({ violations: [] }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'changed', snapshotsDir: tmpDir, title: 'changed mode' })
+      await checkAccessibility(makePage() as any, testInfo as any, { bestPracticeMode: 'off' })
+
+      expect(mockToMatchSnapshot).toHaveBeenCalled()
+    })
+
+    it("uses snapshot mode when updateSnapshots is 'all' (explicit --update-snapshots=all)", async () => {
+      mockAnalyze.mockResolvedValue(makeAxeResults({ violations: [] }))
+
+      const testInfo = makeTestInfo({ updateSnapshots: 'all', snapshotsDir: tmpDir, title: 'all mode' })
+      await checkAccessibility(makePage() as any, testInfo as any, { bestPracticeMode: 'off' })
+
+      expect(mockToMatchSnapshot).toHaveBeenCalled()
+    })
   })
 })

--- a/src/util/accessible-screenshot.ts
+++ b/src/util/accessible-screenshot.ts
@@ -202,8 +202,10 @@ interface ScanContext {
  * 1. Explicit in-code `baseline` option -> baseline mode (existing behaviour).
  * 2. A snapshot file already exists on disk for this test -> snapshot mode
  *    (existing behaviour, preserves all previously committed snapshots).
- * 3. Playwright is in snapshot-update mode (`all`/`changed`/`missing`) ->
- *    snapshot mode (Playwright will create the snapshot).
+ * 3. Playwright is in explicit snapshot-update mode (`all`/`changed`, set via
+ *    `--update-snapshots`) -> snapshot mode (Playwright will create the
+ *    snapshot). `'missing'` is Playwright's default config value and does NOT
+ *    indicate explicit user intent, so it falls through to baseline mode.
  * 4. Otherwise -> on-disk baseline mode. If the JSON file exists, load and
  *    match against it. If it does not, seed it. On CI seeding fails the
  *    test (matching Playwright's missing-snapshot behaviour); locally,
@@ -219,7 +221,7 @@ async function dispatchAssertion(ctx: ScanContext, inCodeBaseline?: Accessibilit
   }
 
   const update = ctx.testInfo.config?.updateSnapshots
-  if (update === 'all' || update === 'changed' || update === 'missing') {
+  if (update === 'all' || update === 'changed') {
     return assertSnapshot(ctx)
   }
 


### PR DESCRIPTION
## Summary

- Playwright's `updateSnapshots` defaults to `'missing'` (per its own [type definition](https://github.com/microsoft/playwright/blob/main/packages/playwright/types/test.d.ts)). PR #120 promised new a11y tests default to baseline mode, but the dispatch in `accessible-screenshot.ts` lumped `'missing'` together with `'all'` and `'changed'` and routed all three to snapshot mode.
- Net effect before this fix: every new a11y test routed to snapshot mode unless the user explicitly set `updateSnapshots: 'none'` in their Playwright config — directly contradicting PR #120's promise.
- Only `'all'` and `'changed'` indicate explicit user intent (set via `--update-snapshots`). `'missing'` is the out-of-the-box default and must fall through to baseline mode.

## Why the tests didn't catch this

The existing dispatch tests covered:
- `updateSnapshots: 'all'` (legacy default in `makeTestInfo`) → snapshot mode ✓
- `updateSnapshots: 'none'` (explicit opt-out used by on-disk baseline tests) → baseline mode ✓

...but never `updateSnapshots: 'missing'`, which is Playwright's actual default. Added explicit cases for `'missing'`, `'changed'`, and `'all'`.

## Test plan

- [x] `npm run test:unit` — 120 passed (was 117 before adding 3 new cases)
- [x] `npx tsc --noEmit` clean
- [x] Local bats integration suite green via husky pre-commit hook
- [ ] CI: lint, type-check, unit, integration, docs build
- [ ] Manual verification: a real project with no Playwright `updateSnapshots` override — new a11y tests should now seed `*.a11y-baseline.json` files instead of creating `*-snapshots/` directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)