### PR TITLE
feat(util): add entities.extractEntityIdFromPage

### DIFF
--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -164,6 +164,27 @@ Races two signals: URL change away from `addFormPathPattern` (returns `'ok'`), o
 !!! note
     `waitForSaveOutcome` throws on timeout. If your test needs a soft "neither happened" branch, wrap the call in `try/catch`.
 
+### Entities
+
+Some Drupal distributions (notably Drupal CMS) add path aliases to freshly created entities, so the post-save redirect lands on `/my-article` rather than `/node/42`. `extractEntityIdFromPage` recovers the numeric ID by falling back to the first canonical edit link on the page.
+
+```typescript
+import { extractEntityIdFromPage } from '@packages/playwright-drupal';
+
+// after saving a node form …
+const nodeId = await extractEntityIdFromPage(page, 'node');
+expect(nodeId).toBeDefined();
+```
+
+**API:** `extractEntityIdFromPage(page: Page, entityType: 'node' | 'media'): Promise<string | undefined>`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `page` | *(required)* | The Playwright page object. |
+| `entityType` | *(required)* | `'node'` or `'media'`. |
+
+Returns the numeric ID as a string, or `undefined` when neither the URL nor any rendered edit link matches `/\<entityType\>/(\\d+)`.
+
 ### Gin theme workarounds
 
 Helpers scoped to quirks introduced by the [Gin](https://www.drupal.org/project/gin) admin theme. Today the only helper is a click wrapper that survives Gin's pinned page header, which routinely overlaps submit buttons near the bottom of a form.

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -176,14 +176,14 @@ const nodeId = await extractEntityIdFromPage(page, 'node');
 expect(nodeId).toBeDefined();
 ```
 
-**API:** `extractEntityIdFromPage(page: Page, entityType: 'node' | 'media'): Promise<string | undefined>`
+**API:** `extractEntityIdFromPage(page: Page, entityType: string): Promise<string | undefined>`
 
 | Parameter | Default | Description |
 |---|---|---|
 | `page` | *(required)* | The Playwright page object. |
-| `entityType` | *(required)* | `'node'` or `'media'`. |
+| `entityType` | *(required)* | The entity type's canonical-route path segment (typically the machine name) — e.g. `'node'`, `'media'`, `'user'`. |
 
-Returns the numeric ID as a string, or `undefined` when neither the URL nor any rendered edit link matches `/\<entityType\>/(\\d+)`.
+Returns the numeric ID as a string, or `undefined` when neither the URL nor any rendered edit link matches `/\<entityType\>/(\\d+)`. Works for any entity whose edit route follows `/<entityType>/<id>/edit`. Entity types routed under `/admin/...` (some config entities) are not handled — that is a separate helper for another day.
 
 ### Gin theme workarounds
 

--- a/src/util/entities.test.ts
+++ b/src/util/entities.test.ts
@@ -34,6 +34,11 @@ describe('extractEntityIdFromPage', () => {
     expect(id).toBe('7');
   });
 
+  it('accepts arbitrary entity types (e.g. user)', async () => {
+    const id = await extractEntityIdFromPage(makePage({ url: 'http://example.test/user/3' }), 'user');
+    expect(id).toBe('3');
+  });
+
   it('returns undefined when neither the URL nor an edit link matches', async () => {
     const id = await extractEntityIdFromPage(
       makePage({ url: 'http://example.test/unrelated', editHref: null }),

--- a/src/util/entities.test.ts
+++ b/src/util/entities.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { extractEntityIdFromPage } from './entities';
+
+function makePage({ url, editHref }: { url: string; editHref?: string | null }) {
+  return {
+    url: () => url,
+    locator: (_sel: string) => ({
+      first: () => ({
+        getAttribute: vi.fn().mockImplementation(() => {
+          if (editHref === undefined) return Promise.reject(new Error('boom'));
+          return Promise.resolve(editHref);
+        }),
+      }),
+    }),
+  } as never;
+}
+
+describe('extractEntityIdFromPage', () => {
+  it('extracts from a direct /node/N URL', async () => {
+    const id = await extractEntityIdFromPage(makePage({ url: 'http://example.test/node/42' }), 'node');
+    expect(id).toBe('42');
+  });
+
+  it('extracts from an edit-link fallback when the URL is path-aliased', async () => {
+    const id = await extractEntityIdFromPage(
+      makePage({ url: 'http://example.test/my-article', editHref: '/node/99/edit' }),
+      'node',
+    );
+    expect(id).toBe('99');
+  });
+
+  it('works for media entities', async () => {
+    const id = await extractEntityIdFromPage(makePage({ url: 'http://example.test/media/7' }), 'media');
+    expect(id).toBe('7');
+  });
+
+  it('returns undefined when neither the URL nor an edit link matches', async () => {
+    const id = await extractEntityIdFromPage(
+      makePage({ url: 'http://example.test/unrelated', editHref: null }),
+      'node',
+    );
+    expect(id).toBeUndefined();
+  });
+
+  it('returns undefined when the edit-link lookup rejects', async () => {
+    const id = await extractEntityIdFromPage(
+      makePage({ url: 'http://example.test/unrelated' }),
+      'node',
+    );
+    expect(id).toBeUndefined();
+  });
+});

--- a/src/util/entities.ts
+++ b/src/util/entities.ts
@@ -1,0 +1,25 @@
+import { Page } from '@playwright/test';
+
+/**
+ * Entity-ID resolution that survives path-aliased save redirects.
+ *
+ * Some Drupal distributions (notably Drupal CMS) add path aliases to freshly
+ * created entities, so the post-save redirect lands on `/my-title` rather
+ * than `/node/42`. `extractEntityIdFromPage` extracts the numeric ID either
+ * from the current URL or, failing that, from the first canonical edit link
+ * rendered on the page.
+ */
+export async function extractEntityIdFromPage(
+  page: Page,
+  entityType: 'node' | 'media',
+): Promise<string | undefined> {
+  const pattern = new RegExp(`/${entityType}/(\\d+)`);
+  const directMatch = page.url().match(pattern)?.[1];
+  if (directMatch) return directMatch;
+  const editHref = await page
+    .locator(`a[href*="/${entityType}/"][href*="/edit"]`)
+    .first()
+    .getAttribute('href')
+    .catch(() => null);
+  return editHref?.match(pattern)?.[1];
+}

--- a/src/util/entities.ts
+++ b/src/util/entities.ts
@@ -8,10 +8,16 @@ import { Page } from '@playwright/test';
  * than `/node/42`. `extractEntityIdFromPage` extracts the numeric ID either
  * from the current URL or, failing that, from the first canonical edit link
  * rendered on the page.
+ *
+ * `entityType` is the path segment used by the entity's canonical route —
+ * typically the machine name (`'node'`, `'media'`, `'user'`, etc.). Works
+ * for any entity whose edit route follows `/<entityType>/<id>/edit`. Entity
+ * types routed under `/admin/...` (for example some config entities) are
+ * not handled here.
  */
 export async function extractEntityIdFromPage(
   page: Page,
-  entityType: 'node' | 'media',
+  entityType: string,
 ): Promise<string | undefined> {
   const pattern = new RegExp(`/${entityType}/(\\d+)`);
   const directMatch = page.url().match(pattern)?.[1];

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,7 @@
 export * from './accessibility-baseline'
 export * from './accessible-screenshot'
 export * from './docroot'
+export * from './entities'
 export * from './forms'
 export * from './frames'
 export * from './gin'


### PR DESCRIPTION
## Summary

Introduces `src/util/entities.ts` with `extractEntityIdFromPage(page, entityType)` — resolves a node or media entity's numeric ID after save. Survives path-aliased redirects by falling back to the first canonical edit link on the page.

## Why

Drupal CMS adds path aliases to freshly created entities, so the post-save URL is `/my-title`, not `/node/42`. Tests that need the ID end up scraping it anyway; landing a shared helper here.

## Stacked PR info

- Base: `docs/testing-utilities` (PR #125)
- Head: `util/entities`

## Plan reference

- Plan: `.ai/task-manager/plans/09--drupal-testing-utilities/plan-09--drupal-testing-utilities.md`
- Task: `tasks/03--entities-ts.md`
- Source: `lsm-autoplay/playwright/utils/formHelpers.ts:65-78`

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 125/125 (5 new)
- [x] `npm run docs:build` (strict) passes
- [x] Docs subsection added at slot 3 (Entities)

🤖 Generated with [Claude Code](https://claude.com/claude-code)