### PR TITLE
feat(util): add Ckeditor5 class

### DIFF
--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -187,14 +187,17 @@ Returns the numeric ID as a string, or `undefined` when neither the URL nor any 
 
 ### CKEditor 5
 
-CKEditor 5 renders inside a contenteditable `<div role="textbox">`, so Playwright's native `fill()` doesn't overwrite existing content the way you'd expect. The `Ckeditor5` class wraps the clear-and-fill idiom: select-all (`Meta+A` on macOS, `Control+A` elsewhere), Backspace, then `fill()`.
+The `Ckeditor5` class drives **CKEditor 5** fields — the editor Drupal core has shipped by default since Drupal 10. It clears any existing content, then types the new value through `page.keyboard` so CKEditor's event pipeline processes the edits correctly (Playwright's `locator.fill()` can be silently dropped because the editor re-renders from its internal model).
+
+!!! warning
+    This class is for CKEditor **5** only. It does not work with CKEditor 4, which Drupal 10 still ships via the `ckeditor` module for sites that opted in. For CKEditor 4 use a plain `page.frameLocator(...)` + `fill()`.
 
 ```typescript
 import { test, Ckeditor5 } from '@packages/playwright-drupal';
 
 test('edits the body copy', async ({ page }) => {
   await page.goto('/node/1/edit');
-  const body = new Ckeditor5(page, '#edit-body-wrapper .ck-editor div[role="textbox"]');
+  const body = new Ckeditor5(page, '#edit-body-wrapper');
   await body.fill('New body text');
 });
 ```
@@ -204,12 +207,12 @@ test('edits the body copy', async ({ page }) => {
 | Parameter | Default | Description |
 |---|---|---|
 | `page` | *(required)* | The owning `Page`. Keyboard events target this page. |
-| `selector` | *(required)* | Selector for the editor's contenteditable element (e.g. `.ck-editor div[role="textbox"]`). |
+| `selector` | *(required)* | Selector for the widget **wrapper** containing the editor (e.g. `#edit-body-wrapper`, `[data-drupal-selector="edit-field-body-wrapper"]`). The class drills into `.ck-editor__editable` internally. |
 | `root` | `page` | Optional `FrameLocator` if the editor renders inside an iframe. |
 
 **API:** `async fill(text: string): Promise<void>`
 
-Waits for the editor to become visible, focuses it, clears existing content, and fills the new text.
+Waits for the editor to become visible, clicks to place the caret, clears existing content via select-all + Backspace (platform-aware), and types the new text. Final value is exactly `text`, regardless of whether the field was empty — matching Playwright's `fill()` semantics.
 
 ### Gin theme workarounds
 

--- a/docs/writing-tests.md
+++ b/docs/writing-tests.md
@@ -185,6 +185,32 @@ expect(nodeId).toBeDefined();
 
 Returns the numeric ID as a string, or `undefined` when neither the URL nor any rendered edit link matches `/\<entityType\>/(\\d+)`. Works for any entity whose edit route follows `/<entityType>/<id>/edit`. Entity types routed under `/admin/...` (some config entities) are not handled — that is a separate helper for another day.
 
+### CKEditor 5
+
+CKEditor 5 renders inside a contenteditable `<div role="textbox">`, so Playwright's native `fill()` doesn't overwrite existing content the way you'd expect. The `Ckeditor5` class wraps the clear-and-fill idiom: select-all (`Meta+A` on macOS, `Control+A` elsewhere), Backspace, then `fill()`.
+
+```typescript
+import { test, Ckeditor5 } from '@packages/playwright-drupal';
+
+test('edits the body copy', async ({ page }) => {
+  await page.goto('/node/1/edit');
+  const body = new Ckeditor5(page, '#edit-body-wrapper .ck-editor div[role="textbox"]');
+  await body.fill('New body text');
+});
+```
+
+**Constructor:** `new Ckeditor5(page: Page, selector: string, root?: Page | FrameLocator)`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `page` | *(required)* | The owning `Page`. Keyboard events target this page. |
+| `selector` | *(required)* | Selector for the editor's contenteditable element (e.g. `.ck-editor div[role="textbox"]`). |
+| `root` | `page` | Optional `FrameLocator` if the editor renders inside an iframe. |
+
+**API:** `async fill(text: string): Promise<void>`
+
+Waits for the editor to become visible, focuses it, clears existing content, and fills the new text.
+
 ### Gin theme workarounds
 
 Helpers scoped to quirks introduced by the [Gin](https://www.drupal.org/project/gin) admin theme. Today the only helper is a click wrapper that survives Gin's pinned page header, which routinely overlaps submit buttons near the bottom of a form.

--- a/src/util/ckeditor5.test.ts
+++ b/src/util/ckeditor5.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { selectAllModifier } from './ckeditor5';
+
+describe('selectAllModifier', () => {
+  it('returns Meta on darwin', () => {
+    expect(selectAllModifier('darwin')).toBe('Meta');
+  });
+
+  it('returns Control on linux', () => {
+    expect(selectAllModifier('linux')).toBe('Control');
+  });
+
+  it('returns Control on win32', () => {
+    expect(selectAllModifier('win32')).toBe('Control');
+  });
+
+  it('returns Control on freebsd / other', () => {
+    expect(selectAllModifier('freebsd')).toBe('Control');
+  });
+});

--- a/src/util/ckeditor5.ts
+++ b/src/util/ckeditor5.ts
@@ -1,0 +1,60 @@
+import { FrameLocator, Page } from '@playwright/test';
+
+/**
+ * Return the select-all modifier key for a given platform.
+ *
+ * Exported so unit tests can cover the platform branch without mocking
+ * `process.platform`. Defaults to the current platform.
+ */
+export function selectAllModifier(platform: NodeJS.Platform = process.platform): 'Meta' | 'Control' {
+  return platform === 'darwin' ? 'Meta' : 'Control';
+}
+
+/**
+ * Fill a CKEditor 5 field with arbitrary text.
+ *
+ * CKEditor 5 renders inside a contenteditable `<div role="textbox">`, so the
+ * native `fill()` behaviour doesn't overwrite existing content in the way
+ * consumers expect. This class clears the field with a cross-platform
+ * select-all (Meta+A on darwin, Control+A elsewhere) followed by Backspace,
+ * then fills the new text.
+ *
+ * Accepts an optional `root` for editors rendered inside an iframe: pass the
+ * `FrameLocator` as `root` while keeping `page` as the owning page so the
+ * keyboard events still reach the right window.
+ */
+export class Ckeditor5 {
+  public page: Page;
+  public root: Page | FrameLocator;
+  protected selector: string;
+
+  /**
+   * @param page
+   *   The page the CKEditor 5 instance lives on. Keyboard events are sent to
+   *   this page.
+   * @param selector
+   *   A selector that resolves to the editor's contenteditable element
+   *   (e.g. `.ck-editor div[role="textbox"]`).
+   * @param root
+   *   Optional frame locator if the editor is inside an iframe. Defaults to
+   *   `page`.
+   */
+  public constructor(page: Page, selector: string, root?: Page | FrameLocator) {
+    this.page = page;
+    this.selector = selector;
+    this.root = root ?? page;
+  }
+
+  /**
+   * Clear the current contents and fill with the given text.
+   */
+  public async fill(text: string): Promise<void> {
+    const editableElement = this.root.locator(this.selector);
+    await editableElement.waitFor({ state: 'visible', timeout: 15000 });
+    await editableElement.focus();
+    const key = selectAllModifier();
+    await this.page.keyboard.press(`${key}+A`);
+    await this.page.keyboard.press('Backspace');
+    await editableElement.fill(text);
+  }
+}

--- a/src/util/ckeditor5.ts
+++ b/src/util/ckeditor5.ts
@@ -11,17 +11,30 @@ export function selectAllModifier(platform: NodeJS.Platform = process.platform):
 }
 
 /**
- * Fill a CKEditor 5 field with arbitrary text.
+ * Drive a CKEditor **5** field from a Playwright test.
  *
- * CKEditor 5 renders inside a contenteditable `<div role="textbox">`, so the
- * native `fill()` behaviour doesn't overwrite existing content in the way
- * consumers expect. This class clears the field with a cross-platform
- * select-all (Meta+A on darwin, Control+A elsewhere) followed by Backspace,
- * then fills the new text.
+ * This class is specifically for CKEditor 5 — the editor Drupal core has
+ * shipped by default since Drupal 10. It does **not** work with CKEditor 4,
+ * which Drupal 10 still ships via the `ckeditor` module for sites that opted
+ * in; use a plain `page.frameLocator(...)` + `fill()` approach for that.
  *
- * Accepts an optional `root` for editors rendered inside an iframe: pass the
- * `FrameLocator` as `root` while keeping `page` as the owning page so the
- * keyboard events still reach the right window.
+ * CKEditor 5 keeps a virtual-DOM model that it synchronises with the visible
+ * contenteditable element. Setting the DOM directly (e.g. via Playwright's
+ * `locator.fill()`) can be silently dropped because the editor's next
+ * re-render overwrites it; it also bypasses any input handlers CKEditor
+ * plugins register. `fill()` here dispatches real keyboard events through
+ * `page.keyboard`, which CKEditor's event pipeline processes as normal
+ * edits.
+ *
+ * The `selector` targets the widget **wrapper** (e.g.
+ * `#edit-field-body-0-value` or `[data-drupal-selector="edit-body-wrapper"]`),
+ * not the contenteditable itself — the class drills into
+ * `.ck-editor__editable` internally so callers don't have to memorise
+ * CKEditor 5's markup.
+ *
+ * For editors rendered inside an iframe, pass the `FrameLocator` as `root`
+ * while keeping `page` as the owning page so keyboard events still reach the
+ * right window.
  */
 export class Ckeditor5 {
   public page: Page;
@@ -33,8 +46,9 @@ export class Ckeditor5 {
    *   The page the CKEditor 5 instance lives on. Keyboard events are sent to
    *   this page.
    * @param selector
-   *   A selector that resolves to the editor's contenteditable element
-   *   (e.g. `.ck-editor div[role="textbox"]`).
+   *   A selector that resolves to the widget wrapper containing the editor
+   *   (e.g. `#edit-field-body-0-value`). The class finds the
+   *   `.ck-editor__editable` element inside.
    * @param root
    *   Optional frame locator if the editor is inside an iframe. Defaults to
    *   `page`.
@@ -46,15 +60,23 @@ export class Ckeditor5 {
   }
 
   /**
-   * Clear the current contents and fill with the given text.
+   * Replace the editor's contents with the given text.
+   *
+   * Clears existing content (select-all + Backspace) so the call has
+   * Playwright-style `fill()` semantics: the final value is exactly `text`,
+   * regardless of whether the field was empty.
    */
   public async fill(text: string): Promise<void> {
-    const editableElement = this.root.locator(this.selector);
-    await editableElement.waitFor({ state: 'visible', timeout: 15000 });
-    await editableElement.focus();
-    const key = selectAllModifier();
-    await this.page.keyboard.press(`${key}+A`);
+    const editable = this.root.locator(this.selector).locator('.ck-editor__editable');
+    await editable.waitFor({ state: 'visible', timeout: 15000 });
+    // Click places the caret inside the editable so the keyboard events
+    // below land in CKEditor rather than the outer document.
+    await editable.click();
+    await this.page.keyboard.press(`${selectAllModifier()}+A`);
     await this.page.keyboard.press('Backspace');
-    await editableElement.fill(text);
+    // keyboard.type fires keydown/keypress/input events that CKEditor 5's
+    // event pipeline processes. locator.fill() would set the DOM directly
+    // and can be silently dropped on the next model re-render.
+    await this.page.keyboard.type(text);
   }
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,6 @@
 export * from './accessibility-baseline'
 export * from './accessible-screenshot'
+export * from './ckeditor5'
 export * from './docroot'
 export * from './entities'
 export * from './forms'


### PR DESCRIPTION
## Summary

Introduces `src/util/ckeditor5.ts` with the `Ckeditor5` class — shared CKEditor 5 fill implementation with cross-platform select-all modifier (`Meta+A` on macOS, `Control+A` elsewhere).

Also exports `selectAllModifier(platform?)` so the platform branch is unit-testable without mocking `process.platform`.

## Why

Every Drupal Playwright suite reimplements the select-all + backspace + fill dance for CKEditor 5. Landing it once upstream avoids Meta-vs-Control drift on CI runners.

## API deviation from lsm-autoplay

Constructor signature is `(page: Page, selector: string, root?: Page | FrameLocator)` — slightly changed from lsm-autoplay's `(page: Page | FrameLocator, selector: string)` because `FrameLocator` does not expose `.keyboard`. Consumers using CKEditor 5 inside an iframe pass the `FrameLocator` as `root` and keep `page` pointing at the owning page.

## Stacked PR info

- Base: `docs/testing-utilities` (PR #125)
- Head: `util/ckeditor5`

## Plan reference

- Plan: `.ai/task-manager/plans/09--drupal-testing-utilities/plan-09--drupal-testing-utilities.md`
- Task: `tasks/07--ckeditor5-ts.md`
- Source: `lsm-autoplay/playwright/utils/ckeditor5.ts`

## Test plan

- [x] `npm run build` passes
- [x] `npm run test:unit` — 124/124 (4 new)
- [x] `npm run docs:build` (strict) passes
- [x] Docs subsection added at slot 7 (CKEditor 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)