### PR TITLE
chore: automerge dependency updates after 3-day stability period

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,17 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["*"],
+      "automerge": true,
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "automerge": false
+    }
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary
- Enables Renovate automerge for all package updates with a 3-day `minimumReleaseAge` stability period
- Excludes GitHub Actions updates from automerge so they continue to require manual review

## Test plan
- [ ] Wait for next Renovate run and confirm non-GHA PRs are labeled for automerge
- [ ] Confirm GitHub Actions update PRs remain without automerge

🤖 Generated with [Claude Code](https://claude.com/claude-code)