### PR TITLE
feat(login): accept numeric user ID

### DIFF
--- a/src/util/login.test.ts
+++ b/src/util/login.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../testcase/test', () => ({
+  execDrushInTestSite: vi.fn(),
+}));
+
+import { execDrushInTestSite } from '../testcase/test';
+import { login } from './login';
+
+const mockedDrush = vi.mocked(execDrushInTestSite);
+
+interface FakePage {
+  goto: ReturnType<typeof vi.fn>;
+  context: () => { cookies: ReturnType<typeof vi.fn> };
+}
+
+function fakePage(cookies: { name: string }[] = [{ name: 'SSESSabc' }]): FakePage {
+  return {
+    goto: vi.fn().mockResolvedValue(undefined),
+    context: () => ({ cookies: vi.fn().mockResolvedValue(cookies) }),
+  };
+}
+
+describe('login', () => {
+  beforeEach(() => mockedDrush.mockReset());
+
+  it('defaults to the admin username', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/1/abc\n',
+      stderr: '',
+    } as never);
+    await login(fakePage() as never);
+    expect(mockedDrush).toHaveBeenCalledWith('user:login --name=admin');
+  });
+
+  it('passes a string argument as --name', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/2/xyz',
+      stderr: '',
+    } as never);
+    await login(fakePage() as never, 'editor');
+    expect(mockedDrush).toHaveBeenCalledWith('user:login --name=editor');
+  });
+
+  it('passes a number argument as --uid', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/42/xyz',
+      stderr: '',
+    } as never);
+    await login(fakePage() as never, 42);
+    expect(mockedDrush).toHaveBeenCalledWith('user:login --uid=42');
+  });
+
+  it('shell-quotes usernames with metacharacters', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/1/abc',
+      stderr: '',
+    } as never);
+    await login(fakePage() as never, 'evil; rm -rf /');
+    const command = mockedDrush.mock.calls[0][0] as string;
+    expect(command).toContain("--name='evil; rm -rf /'");
+  });
+
+  it('navigates to the path + search from the login URL, not the absolute URL', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/1/abc/def?destination=/node/5',
+      stderr: '',
+    } as never);
+    const page = fakePage();
+    await login(page as never);
+    expect(page.goto).toHaveBeenCalledWith(
+      '/user/reset/1/abc/def?destination=/node/5',
+    );
+  });
+
+  it('accepts SESS (HTTP) session cookies as well as SSESS (HTTPS)', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/1/abc',
+      stderr: '',
+    } as never);
+    await expect(
+      login(fakePage([{ name: 'SESSabc' }]) as never),
+    ).resolves.toBeUndefined();
+  });
+
+  it('throws when no Drupal session cookie is present after the redirect', async () => {
+    mockedDrush.mockResolvedValueOnce({
+      stdout: 'http://example.test/user/reset/1/abc',
+      stderr: '',
+    } as never);
+    await expect(login(fakePage([]) as never)).rejects.toThrow(
+      /no Drupal session cookie/,
+    );
+  });
+});

--- a/src/util/login.ts
+++ b/src/util/login.ts
@@ -10,12 +10,19 @@ import { quote as shellQuote } from 'shell-quote';
  * cookie, which works with any theme and any login redirect configuration.
  *
  * @param page - The Playwright page object.
- * @param user - The Drupal username to log in as (defaults to "admin").
+ * @param user - The Drupal user to log in as. A string is treated as a
+ *   username (`--name=`); a number is treated as a user ID (`--uid=`).
+ *   Defaults to the "admin" username.
  */
-export async function login(page: Page, user: string = 'admin') {
-  // Generate a one-time login link for the user.
-  const safeUser = shellQuote([user]);
-  const result = await execDrushInTestSite(`user:login --name=${safeUser}`);
+export async function login(page: Page, user: string | number = 'admin') {
+  // Generate a one-time login link for the user. Numbers map to --uid so
+  // callers that already have a uid from a prior Drush call can pass it
+  // directly instead of round-tripping through a name lookup.
+  const flag =
+    typeof user === 'number'
+      ? `--uid=${shellQuote([String(user)])}`
+      : `--name=${shellQuote([user])}`;
+  const result = await execDrushInTestSite(`user:login ${flag}`);
   const loginUrl = result.stdout.trim();
 
   // drush user:login returns an absolute URL (e.g. http://...). Extract the


### PR DESCRIPTION
## Summary
- `login(page, user)` now accepts a `number` in addition to a `string`. Numbers are forwarded to `drush user:login` as `--uid=`; strings keep the existing `--name=` path. Default (`'admin'`) is unchanged.
- Tests that already have a uid in hand (e.g. from a previous Drush call that minted a user) can skip the name round-trip.

## Test plan
- [x] `npm run test:unit` — 179 tests pass, including 7 new `login.test.ts` cases covering the default, string, uid, shell-quoting, URL parsing, both session-cookie variants, and the missing-cookie failure path.
- [x] Pre-commit `npm run test:bats` DDEV integration suite (ran automatically under \$CLAUDECODE).
- [ ] Sanity-check on a real Drupal site: `login(page, 1)` reaches the admin dashboard with a valid session cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)