### PR TITLE
fix(entities): resolve entity ID via drupalSettings on pathauto-aliased redirects

### DIFF
--- a/src/util/entities.test.ts
+++ b/src/util/entities.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect, vi } from 'vitest';
 import { extractEntityIdFromPage } from './entities';
 
-function makePage({ url, editHref }: { url: string; editHref?: string | null }) {
+function makePage({
+  url,
+  editHref,
+  currentPath,
+}: {
+  url: string;
+  editHref?: string | null;
+  currentPath?: string | null;
+}) {
   return {
     url: () => url,
+    evaluate: vi.fn().mockImplementation(() => {
+      if (currentPath === undefined) return Promise.reject(new Error('boom'));
+      return Promise.resolve(currentPath);
+    }),
     locator: (_sel: string) => ({
       first: () => ({
         getAttribute: vi.fn().mockImplementation(() => {
@@ -21,9 +33,21 @@ describe('extractEntityIdFromPage', () => {
     expect(id).toBe('42');
   });
 
-  it('extracts from an edit-link fallback when the URL is path-aliased', async () => {
+  it('extracts from drupalSettings.path.currentPath when the URL is path-aliased and no canonical edit link is rendered', async () => {
     const id = await extractEntityIdFromPage(
-      makePage({ url: 'http://example.test/my-article', editHref: '/node/99/edit' }),
+      makePage({
+        url: 'http://example.test/news/my-article',
+        currentPath: 'node/99',
+        editHref: '/news/my-article/edit',
+      }),
+      'node',
+    );
+    expect(id).toBe('99');
+  });
+
+  it('extracts from an edit-link fallback when the URL is path-aliased and drupalSettings is unavailable', async () => {
+    const id = await extractEntityIdFromPage(
+      makePage({ url: 'http://example.test/my-article', currentPath: null, editHref: '/node/99/edit' }),
       'node',
     );
     expect(id).toBe('99');
@@ -39,15 +63,15 @@ describe('extractEntityIdFromPage', () => {
     expect(id).toBe('3');
   });
 
-  it('returns undefined when neither the URL nor an edit link matches', async () => {
+  it('returns undefined when URL, drupalSettings, and edit link all miss', async () => {
     const id = await extractEntityIdFromPage(
-      makePage({ url: 'http://example.test/unrelated', editHref: null }),
+      makePage({ url: 'http://example.test/unrelated', currentPath: null, editHref: null }),
       'node',
     );
     expect(id).toBeUndefined();
   });
 
-  it('returns undefined when the edit-link lookup rejects', async () => {
+  it('returns undefined when every lookup rejects', async () => {
     const id = await extractEntityIdFromPage(
       makePage({ url: 'http://example.test/unrelated' }),
       'node',

--- a/src/util/entities.ts
+++ b/src/util/entities.ts
@@ -3,11 +3,15 @@ import { Page } from '@playwright/test';
 /**
  * Entity-ID resolution that survives path-aliased save redirects.
  *
- * Some Drupal distributions (notably Drupal CMS) add path aliases to freshly
- * created entities, so the post-save redirect lands on `/my-title` rather
- * than `/node/42`. `extractEntityIdFromPage` extracts the numeric ID either
- * from the current URL or, failing that, from the first canonical edit link
- * rendered on the page.
+ * On sites that use pathauto (optionally with subpathauto), freshly
+ * created entities get auto-aliased immediately, so the post-save
+ * redirect lands on `/my-title` rather than `/node/42`, and every edit
+ * link rendered on the page is also aliased.
+ * `extractEntityIdFromPage` extracts the numeric ID from, in order:
+ * 1. a canonical `/{entityType}/N` segment in the current URL,
+ * 2. `drupalSettings.path.currentPath`, which Drupal core always
+ *    populates with the unaliased internal route path (e.g. `node/42`),
+ * 3. the first canonical `/{entityType}/N/edit` link rendered on the page.
  *
  * `entityType` is the path segment used by the entity's canonical route —
  * typically the machine name (`'node'`, `'media'`, `'user'`, etc.). Works
@@ -19,9 +23,17 @@ export async function extractEntityIdFromPage(
   page: Page,
   entityType: string,
 ): Promise<string | undefined> {
-  const pattern = new RegExp(`/${entityType}/(\\d+)`);
+  const pattern = new RegExp(`(?:^|/)${entityType}/(\\d+)`);
   const directMatch = page.url().match(pattern)?.[1];
   if (directMatch) return directMatch;
+  const currentPath = await page
+    .evaluate(() => {
+      const w = window as unknown as { drupalSettings?: { path?: { currentPath?: string } } };
+      return w.drupalSettings?.path?.currentPath ?? null;
+    })
+    .catch(() => null);
+  const settingsMatch = currentPath?.match(pattern)?.[1];
+  if (settingsMatch) return settingsMatch;
   const editHref = await page
     .locator(`a[href*="/${entityType}/"][href*="/edit"]`)
     .first()


### PR DESCRIPTION
## Summary

- On sites with `pathauto` (+ optional `subpathauto`), freshly-created entities get auto-aliased immediately. The post-save redirect lands on e.g. `/news/my-title` rather than `/node/42`, and every edit link rendered on the resulting page is also aliased — so the existing two-step lookup in `extractEntityIdFromPage` (URL match, then a canonical `/{entityType}/N/edit` link) finds nothing and the helper returns `undefined`.
- Adds `drupalSettings.path.currentPath` as a middle fallback. Drupal core always populates this from the route match (see `web/core/modules/system/src/Hook/SystemHooks.php`), so it's the unaliased internal path (e.g. `node/42`) regardless of any alias logic.
- Broadens the regex from `/${entityType}/(\\d+)` to `(?:^|/)${entityType}/(\\d+)` so it also matches the path-relative form Drupal emits (`node/42`, no leading slash).
- Docstring updated to describe the real culprit (pathauto) rather than "Drupal CMS" specifically.

## Test plan

- [x] `npm run test:unit` — 180 passing, including new cases covering the aliased URL + `drupalSettings` fallback, and the aliased URL + canonical-edit-link fallback.
- [x] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)