### PR TITLE
docs: show latest alias in version menu

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,6 +54,7 @@ markdown_extensions:
 extra:
   version:
     provider: mike
+    alias: true
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- Adds `alias: true` under `extra.version` in `mkdocs.yml` so mkdocs-material renders mike aliases as their own entries in the version dropdown.
- Surfaces a stable `latest` link in the menu alongside the numbered releases (`1.7.1`, `1.7.0`, …); the `latest` alias is already published by the existing `Deploy Docs` workflow.

## Test plan
- [ ] After merge, confirm the deployed docs show `latest` as a separate selectable entry in the version dropdown and that it routes to `/playwright-drupal/latest/`.
- [ ] Confirm the existing numbered versions still appear and resolve correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)