### PR TITLE
docs: show all published versions in tugboat previews

### DIFF
--- a/.tugboat/build.sh
+++ b/.tugboat/build.sh
@@ -6,12 +6,13 @@ export PATH="$HOME/.local/bin:$PATH"
 cd "${TUGBOAT_ROOT}"
 
 # Pull the published docs (all versions) from gh-pages so the version
-# dropdown is populated in the preview.
-git fetch --no-tags --depth=1 origin gh-pages
-
+# dropdown is populated in the preview. We download a tarball over
+# HTTPS rather than `git fetch`-ing because the build container has no
+# SSH credentials for the configured `git@github.com:…` remote.
+GH_PAGES_TARBALL="https://codeload.github.com/Lullabot/playwright-drupal/tar.gz/refs/heads/gh-pages"
 rm -rf "${TUGBOAT_ROOT}/site"
 mkdir -p "${TUGBOAT_ROOT}/site"
-git archive --format=tar FETCH_HEAD | tar -x -C "${TUGBOAT_ROOT}/site"
+curl -fsSL "${GH_PAGES_TARBALL}" | tar -xz --strip-components=1 -C "${TUGBOAT_ROOT}/site"
 
 # Build this preview's docs into their own version directory alongside
 # the published versions.

--- a/.tugboat/build.sh
+++ b/.tugboat/build.sh
@@ -24,8 +24,9 @@ uvx --with-requirements "${TUGBOAT_ROOT}/docs/requirements.txt" \
   --site-dir "${TUGBOAT_ROOT}/site/${PREVIEW_VERSION}"
 
 # Add the preview to versions.json and make it the landing page so
-# reviewers see the PR's changes first.
-python3 - <<'PY'
+# reviewers see the PR's changes first. The base httpd image has no
+# system python3, so we borrow uv's managed interpreter.
+uv run --no-project --quiet --python 3 python - <<'PY'
 import json, os
 site = os.path.join(os.environ["TUGBOAT_ROOT"], "site")
 preview = os.environ["PREVIEW_VERSION"]

--- a/.tugboat/build.sh
+++ b/.tugboat/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$HOME/.local/bin:$PATH"
+
+cd "${TUGBOAT_ROOT}"
+
+# Pull the published docs (all versions) from gh-pages so the version
+# dropdown is populated in the preview.
+git fetch --no-tags --depth=1 origin gh-pages
+
+rm -rf "${TUGBOAT_ROOT}/site"
+mkdir -p "${TUGBOAT_ROOT}/site"
+git archive --format=tar FETCH_HEAD | tar -x -C "${TUGBOAT_ROOT}/site"
+
+# Build this preview's docs into their own version directory alongside
+# the published versions.
+PREVIEW_VERSION="preview-${TUGBOAT_PREVIEW_ID:-local}"
+export PREVIEW_VERSION
+uvx --with-requirements "${TUGBOAT_ROOT}/docs/requirements.txt" \
+  mkdocs build --strict \
+  --config-file "${TUGBOAT_ROOT}/mkdocs.yml" \
+  --site-dir "${TUGBOAT_ROOT}/site/${PREVIEW_VERSION}"
+
+# Add the preview to versions.json and make it the landing page so
+# reviewers see the PR's changes first.
+python3 - <<'PY'
+import json, os
+site = os.path.join(os.environ["TUGBOAT_ROOT"], "site")
+preview = os.environ["PREVIEW_VERSION"]
+
+versions_path = os.path.join(site, "versions.json")
+with open(versions_path) as f:
+    versions = json.load(f)
+versions = [v for v in versions if v["version"] != preview]
+versions.insert(0, {"version": preview, "title": f"{preview} (this PR)", "aliases": []})
+with open(versions_path, "w") as f:
+    json.dump(versions, f, indent=2)
+
+with open(os.path.join(site, "index.html"), "w") as f:
+    f.write(
+        '<!DOCTYPE html><html><head>'
+        f'<meta http-equiv="refresh" content="0; url={preview}/">'
+        f'</head><body><a href="{preview}/">{preview}</a></body></html>'
+    )
+PY

--- a/.tugboat/config.yml
+++ b/.tugboat/config.yml
@@ -8,5 +8,5 @@ services:
         - curl -LsSf https://astral.sh/uv/0.11.8/install.sh | sh
 
       build:
-        - export PATH="$HOME/.local/bin:$PATH" && uvx --with-requirements ${TUGBOAT_ROOT}/docs/requirements.txt mkdocs build --strict --config-file ${TUGBOAT_ROOT}/mkdocs.yml
+        - bash ${TUGBOAT_ROOT}/.tugboat/build.sh
         - ln -snf ${TUGBOAT_ROOT}/site ${DOCROOT}


### PR DESCRIPTION
## Summary
- Adds `.tugboat/build.sh`, which fetches `gh-pages` (all published doc versions) into the preview's doc root, then builds the PR's docs into a `preview-${TUGBOAT_PREVIEW_ID}` directory alongside them.
- Patches `versions.json` to add the preview entry and rewrites the root `index.html` so the preview is the landing page; the version dropdown still surfaces every released version (`main`, `1.7.1`, `latest`, `1.7.0`, `1.6.0`).
- Updates `.tugboat/config.yml` to invoke the script.

## Test plan
- [ ] Tugboat builds the preview successfully and lands on the `preview-…` version of the docs.
- [ ] The mkdocs-material version dropdown lists `preview-…`, `main`, `1.7.1`, `latest`, `1.7.0`, `1.6.0` and each entry navigates correctly.
- [ ] Selecting a non-preview version (e.g. `1.6.0`) loads the published content from `gh-pages`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)