### PR TITLE
chore: surface docs commits in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,21 @@
   "release-type": "node",
   "include-v-in-tag": false,
   "packages": {
-    ".": {}
+    ".": {
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "docs", "section": "Documentation" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "deps", "section": "Dependencies" },
+        { "type": "chore", "section": "Miscellaneous Chores", "hidden": true },
+        { "type": "refactor", "section": "Code Refactoring", "hidden": true },
+        { "type": "test", "section": "Tests", "hidden": true },
+        { "type": "build", "section": "Build System", "hidden": true },
+        { "type": "ci", "section": "Continuous Integration", "hidden": true },
+        { "type": "style", "section": "Styles", "hidden": true }
+      ]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Override the default release-please-node `changelog-sections` so `docs:` commits are unhidden — they get listed under "Documentation" in `CHANGELOG.md` and trigger a patch release on their own (instead of being silently dropped).
- All other non-user-facing types (`chore`, `refactor`, `test`, `build`, `ci`, `style`) stay hidden, matching prior behavior. `feat`, `fix`, `perf`, `revert`, `deps` are listed explicitly so the section names are stable.

## Why
Now that the docs site is versioned via mike, doc-only changes are user-visible and worth cutting a release for — both to publish a new versioned site and to make the `latest` alias point at the rebuilt docs.

## Test plan
- [ ] After merge, push a `docs:` commit (or rebase one in) and confirm release-please opens a release PR with the commit listed under "Documentation".
- [ ] Confirm non-doc/non-feat/non-fix commits (e.g. `chore(deps):`) still don't trigger a release on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)