### PR TITLE
docs: fix installation instructions

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -39,12 +39,7 @@ ddev exec -d /var/www/html/test/playwright npx playwright test
 ## Add the playwright-drupal Integration
 
 ```console
-ddev exec -d /var/www/html/test/playwright npm i lullabot/playwright-drupal
-```
-
-```console
-# Or, to pull from GitHub's main branch:
-ddev exec -d /var/www/html/test/playwright npm i lullabot/playwright-drupal@github:Lullabot/playwright-drupal
+ddev exec -d /var/www/html/test/playwright npm i @lullabot/playwright-drupal@latest
 ```
 
 ## Configure Playwright
@@ -119,7 +114,7 @@ includes:
 
 ## Add Playwright to Drupal's Settings
 
-Add the following to your Drupal `sites/default/settings.php` (e.g. `web/sites/default/settings.php` or `docroot/sites/default/settings.php`, depending on your project). A `file_exists()` guard is used so that Drupal can still boot normally when the package is not installed:
+Add the following to your Drupal `sites/default/settings.php` (e.g. `web/sites/default/settings.php` or `docroot/sites/default/settings.php`, depending on your project). It must be added *after* any local-environment access settings (such as the `settings.ddev.php` include DDEV adds), so that this configuration takes precedence when running tests. A `file_exists()` guard is used so that Drupal can still boot normally when the package is not installed:
 
 ```php
 if (file_exists('../test/playwright/node_modules/@lullabot/playwright-drupal/settings/settings.playwright.php')) {


### PR DESCRIPTION
## Summary
- Fix the `npm i` command on the [installation page](https://lullabot.github.io/playwright-drupal/latest/getting-started/installation/#add-the-playwright-drupal-integration) — use the scoped npm package name and `@latest` tag (`@lullabot/playwright-drupal@latest`). The prior `lullabot/playwright-drupal` resolved to a GitHub shorthand and pulled an unbuilt source tree.
- Remove the "install from main" snippet. `lib/` is gitignored and the package's `prepare` script only runs husky, so `npm i ...@github:Lullabot/playwright-drupal` leaves imports like `@lullabot/playwright-drupal/config` unresolved. Documenting the extra clone+build steps would be more friction than it's worth; users who want bleeding-edge can build locally.
- Clarify on [the settings page section](https://lullabot.github.io/playwright-drupal/latest/getting-started/installation/#add-playwright-to-drupals-settings) that the `settings.playwright.php` include must come *after* any local-environment access settings (e.g. the `settings.ddev.php` include DDEV adds), so the test configuration takes precedence.

## Test plan
- [ ] Confirm the rendered docs page reads cleanly after the placement note edit
- [ ] Spot-check that `ddev exec -d /var/www/html/test/playwright npm i @lullabot/playwright-drupal@latest` works in a fresh project
- [ ] Verify the install page no longer mentions the GitHub-main install option

🤖 Generated with [Claude Code](https://claude.com/claude-code)