### PR TITLE
fix(images): report images that never decode instead of giving up silently

### DIFF
--- a/docs/working-with-tests/drupal-testing-utilities.md
+++ b/docs/working-with-tests/drupal-testing-utilities.md
@@ -340,6 +340,17 @@ Scrolls each matching image into view (to trigger lazy loading) and waits for th
 
 Shorthand for [`waitForImages(page, 'img:visible')`](#waitforimages).
 
+### waitForImagesToDecode()
+
+`waitForImagesToDecode(page: Page, timeoutMs?: number): Promise<string[]>`
+
+| Parameter | Default | Description |
+|---|---|---|
+| `page` | *(required)* | The Playwright page object. |
+| `timeoutMs` | `15000` | How long to wait for images to decode before giving up. |
+
+Called by [`waitForImages()`](#waitforimages); call it directly only to use a different timeout or to assert on the result. Waits for every visible image to decode, re-requesting any that errored with a cache-busting query parameter so a slow on-demand fetch can recover. Images that never decode are not an error. Instead, they are warned about on the console and returned, so a broken image in a screenshot has an explanation instead of just a pixel diff.
+
 ### waitForFonts()
 
 `waitForFonts(page: Page): Promise<void>`

--- a/src/util/images.test.ts
+++ b/src/util/images.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+import { decodeVisibleImages, waitForImagesToDecode } from './images'
+
+/**
+ * A stand-in for the parts of HTMLImageElement decodeVisibleImages() touches.
+ *
+ * decodeVisibleImages() runs in the browser, so it is exercised here against a
+ * fake DOM rather than a real page: each image declares whether it is loaded,
+ * still loading, or broken, and a broken one can be told to recover the way a
+ * Stage File Proxy URL does once its on-demand fetch finishes.
+ */
+interface FakeImageOptions {
+  src?: string
+  currentSrc?: string
+  width?: number
+  height?: number
+  rect?: { width: number, height: number }
+  style?: { visibility?: string, display?: string }
+  /** 'loaded', 'loading' (never completes on its own), or 'broken'. */
+  state?: 'loaded' | 'loading' | 'broken'
+  /** Whether a re-request makes a broken image decode. */
+  recoversOnReload?: boolean
+  /** <source> elements of an enclosing <picture>, if any. */
+  sources?: string[]
+}
+
+function makeImage(options: FakeImageOptions = {}) {
+  const state = options.state ?? 'loaded'
+  const sources = options.sources
+  let src = options.src ?? 'https://example.com/image.jpg'
+  let broken = state === 'broken'
+
+  const img: any = {
+    width: options.width ?? 100,
+    height: options.height ?? 100,
+    complete: state !== 'loading',
+    naturalWidth: state === 'loaded' ? 100 : 0,
+    currentSrc: options.currentSrc ?? '',
+    removedAttributes: [] as string[],
+    picture: sources
+      ? {
+        sources: sources.slice(),
+        querySelectorAll: (_selector: string) =>
+          img.picture.sources.map((name: string) => ({
+            remove: () => {
+              img.picture.sources = img.picture.sources.filter((s: string) => s !== name)
+            },
+          })),
+      }
+      : null,
+    getBoundingClientRect: () => options.rect ?? { width: 100, height: 100 },
+    style: {
+      visibility: options.style?.visibility ?? 'visible',
+      display: options.style?.display ?? 'block',
+    },
+    decode: () => (broken ? Promise.reject(new Error('decode failed')) : Promise.resolve()),
+    closest: (selector: string) => (selector === 'picture' ? img.picture : null),
+    removeAttribute: (name: string) => {
+      img.removedAttributes.push(name)
+    },
+    /** Pretend the network finished, for images that start out loading. */
+    finishLoading: () => {
+      img.complete = true
+      img.naturalWidth = 100
+    },
+  }
+
+  Object.defineProperty(img, 'src', {
+    get: () => src,
+    set: (value: string) => {
+      src = value
+      // A re-request clears whatever the browser had resolved from srcset.
+      img.currentSrc = ''
+      if (options.recoversOnReload) {
+        broken = false
+        img.naturalWidth = 100
+      }
+    },
+  })
+
+  return img
+}
+
+function stubDom(images: any[]) {
+  vi.stubGlobal('document', { images })
+  vi.stubGlobal('location', { href: 'https://example.com/page' })
+  vi.stubGlobal('getComputedStyle', (element: any) => element.style)
+}
+
+// Real timers, so the polling is real: keep the intervals tiny.
+const fast = { pollMs: 1, reloadIntervalMs: 0 }
+
+describe('decodeVisibleImages', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns no failures when every visible image has decoded', async () => {
+    stubDom([makeImage(), makeImage()])
+
+    expect(await decodeVisibleImages({ timeoutMs: 1000, ...fast })).toEqual([])
+  })
+
+  it('treats a dimensionless but decodable image as loaded', async () => {
+    // An SVG with no intrinsic size is complete with a naturalWidth of 0, but
+    // decode() resolves for it. It must not be re-requested or reported.
+    const svg = makeImage({ src: 'https://example.com/logo.svg', state: 'broken' })
+    svg.decode = () => Promise.resolve()
+    stubDom([svg])
+
+    expect(await decodeVisibleImages({ timeoutMs: 1000, ...fast })).toEqual([])
+    expect(svg.src).toBe('https://example.com/logo.svg')
+  })
+
+  it('ignores 1x1, zero-size, and hidden images even when they are broken', async () => {
+    stubDom([
+      makeImage({ state: 'broken', width: 1, height: 1 }),
+      makeImage({ state: 'broken', rect: { width: 0, height: 0 } }),
+      makeImage({ state: 'broken', style: { visibility: 'hidden' } }),
+      makeImage({ state: 'broken', style: { display: 'none' } }),
+    ])
+
+    expect(await decodeVisibleImages({ timeoutMs: 0, ...fast })).toEqual([])
+  })
+
+  it('waits for an image that is still loading', async () => {
+    const loading = makeImage({ state: 'loading' })
+    stubDom([loading])
+    setTimeout(() => loading.finishLoading(), 5)
+
+    expect(await decodeVisibleImages({ timeoutMs: 2000, ...fast })).toEqual([])
+  })
+
+  it('re-requests a broken image and reports success once it decodes', async () => {
+    const broken = makeImage({
+      src: 'https://example.com/broken.jpg',
+      currentSrc: 'https://example.com/broken-800.jpg',
+      state: 'broken',
+      recoversOnReload: true,
+      sources: ['source-1', 'source-2'],
+    })
+    stubDom([broken])
+
+    expect(await decodeVisibleImages({ timeoutMs: 2000, ...fast })).toEqual([])
+    // The retry reuses the URL already resolved from srcset, cache-busted...
+    expect(broken.src).toMatch(/^https:\/\/example\.com\/broken-800\.jpg\?playwrightReload=\d+$/)
+    // ...with the responsive sources dropped so that exact URL is fetched.
+    expect(broken.removedAttributes).toContain('srcset')
+    expect(broken.picture.sources).toEqual([])
+  })
+
+  it('leaves data: URLs alone', async () => {
+    const data = makeImage({ src: 'data:image/png;base64,AAAA', state: 'broken' })
+    stubDom([data])
+
+    expect(await decodeVisibleImages({ timeoutMs: 0, ...fast })).toEqual(['data:image/png;base64,AAAA'])
+    expect(data.src).toBe('data:image/png;base64,AAAA')
+  })
+
+  it('reports the images that never decode instead of returning silently', async () => {
+    const broken = makeImage({ src: 'https://example.com/missing.jpg', state: 'broken' })
+    const loading = makeImage({ src: 'https://example.com/slow.jpg', state: 'loading' })
+    stubDom([makeImage(), broken, loading])
+
+    const undecoded = await decodeVisibleImages({ timeoutMs: 20, ...fast })
+
+    // The cache-busting parameter the retries added is stripped back off, so
+    // the reported URL is the one the page asked for.
+    expect(undecoded).toEqual([
+      'https://example.com/missing.jpg',
+      'https://example.com/slow.jpg',
+    ])
+  })
+
+  it('checks the images at least once even with an elapsed timeout', async () => {
+    stubDom([makeImage({ src: 'https://example.com/missing.jpg', state: 'broken' })])
+
+    expect(await decodeVisibleImages({ timeoutMs: 0, ...fast })).toEqual([
+      'https://example.com/missing.jpg',
+    ])
+  })
+})
+
+describe('waitForImagesToDecode', () => {
+  let warn: any
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  function makePage(undecoded: string[]) {
+    return {
+      evaluate: vi.fn().mockResolvedValue(undecoded),
+    } as any
+  }
+
+  it('runs the decode poll in the page with the requested timeout', async () => {
+    const page = makePage([])
+
+    expect(await waitForImagesToDecode(page, 5000)).toEqual([])
+    // The browser-side function is handed to evaluate() by reference so
+    // Playwright serializes it: it must not be wrapped in a closure over
+    // anything in this module.
+    expect(page.evaluate).toHaveBeenCalledWith(decodeVisibleImages, { timeoutMs: 5000 })
+    expect(warn).not.toHaveBeenCalled()
+  })
+
+  it('defaults to a 15 second timeout', async () => {
+    const page = makePage([])
+
+    await waitForImagesToDecode(page)
+
+    expect(page.evaluate).toHaveBeenCalledWith(decodeVisibleImages, { timeoutMs: 15000 })
+  })
+
+  it('warns about, and returns, the images that never decoded', async () => {
+    const page = makePage(['https://example.com/a.jpg', 'https://example.com/b.jpg'])
+
+    const undecoded = await waitForImagesToDecode(page, 1000)
+
+    expect(undecoded).toEqual(['https://example.com/a.jpg', 'https://example.com/b.jpg'])
+    expect(warn).toHaveBeenCalledTimes(1)
+    expect(warn.mock.calls[0][0]).toContain('2 image(s) did not finish loading within 1000ms')
+    expect(warn.mock.calls[0][0]).toContain('https://example.com/a.jpg, https://example.com/b.jpg')
+  })
+})

--- a/src/util/images.ts
+++ b/src/util/images.ts
@@ -93,7 +93,7 @@ export async function waitForAllImages(page: Page): Promise<void> {
 }
 
 /**
- * Wait for every visible image to finish decoding, recovering errored ones.
+ * Poll every visible image until it decodes, re-requesting errored ones.
  *
  * A loaded image is `complete` with a `naturalWidth` greater than zero. An
  * errored request (a 404, or a Stage File Proxy URL that returns a 503 while it
@@ -101,86 +101,145 @@ export async function waitForAllImages(page: Page): Promise<void> {
  * would otherwise be screenshotted as a broken image. A zero `naturalWidth` is
  * ambiguous, though -- a valid but dimensionless image such as an SVG without an
  * intrinsic size reports it too -- so `decode()` disambiguates: it rejects only
- * for a genuine failure. A broken image never recovers on its own, so it is re-requested
- * with a cache-busting query parameter -- by then the on-demand fetch triggered
- * by the first request has usually finished, so the retry resolves to a real
- * image. The retry reuses `currentSrc` (the URL already chosen from `srcset`)
- * and drops the responsive sources so that exact image loads, keeping the render
- * identical to a clean first load. 1x1 visually-hidden images are skipped, and
- * the whole thing is bounded by a timeout.
+ * for a genuine failure. A broken image never recovers on its own, so it is
+ * re-requested with a cache-busting query parameter -- by then the on-demand
+ * fetch triggered by the first request has usually finished, so the retry
+ * resolves to a real image. The retry reuses `currentSrc` (the URL already
+ * chosen from `srcset`) and drops the responsive sources so that exact image
+ * loads, keeping the render identical to a clean first load. 1x1
+ * visually-hidden images are skipped.
+ *
+ * This runs in the browser via `page.evaluate()`, which serializes the function
+ * source, so it must stay self-contained and reference nothing else in this
+ * module. It is exported separately from waitForImagesToDecode() so the polling
+ * can be tested directly.
+ *
+ * Every image is checked at least once, even with a timeout of zero, and the
+ * images that never settled are returned rather than swallowed so the caller
+ * can report them.
+ *
+ * @param options.timeoutMs How long to keep polling before giving up.
+ * @param options.pollMs How long to sleep between polls.
+ * @param options.reloadIntervalMs How long to leave a re-requested image to
+ *   resolve before re-requesting it again.
+ * @returns The URLs of the images that never decoded. Empty when they all did.
+ */
+export async function decodeVisibleImages(
+  options: {timeoutMs: number, pollMs?: number, reloadIntervalMs?: number}
+): Promise<string[]> {
+  const timeoutMs = options.timeoutMs;
+  const pollMs = options.pollMs ?? 250;
+  const reloadIntervalMs = options.reloadIntervalMs ?? 2000;
+  const deadline = Date.now() + timeoutMs;
+  const isCandidate = (img: HTMLImageElement) => {
+    // Skip 1x1 visually-hidden images (see waitForImages above).
+    if (img.width <= 1 && img.height <= 1) {
+      return false;
+    }
+    const rect = img.getBoundingClientRect();
+    if (rect.width === 0 || rect.height === 0) {
+      return false;
+    }
+    const style = getComputedStyle(img);
+    return style.visibility !== "hidden" && style.display !== "none";
+  };
+  const reload = (img: HTMLImageElement) => {
+    const src = img.currentSrc || img.src;
+    if (!src || src.startsWith("data:")) {
+      return;
+    }
+    try {
+      const url = new URL(src, location.href);
+      url.searchParams.set("playwrightReload", String(Date.now()));
+      // Drop the responsive sources so the resolved URL we just loaded is the
+      // one fetched, instead of re-running srcset selection.
+      const picture = img.closest("picture");
+      if (picture) {
+        picture.querySelectorAll("source").forEach(source => source.remove());
+      }
+      img.removeAttribute("srcset");
+      img.src = url.href;
+    } catch {
+      // Ignore anything that is not a reloadable URL.
+    }
+  };
+
+  let lastReload = 0;
+  // Checking before testing the deadline means a zero or already-elapsed
+  // timeout still reports on the images instead of claiming success.
+  for (;;) {
+    const candidates = Array.from(document.images).filter(isCandidate);
+    // Collect the verdicts positionally rather than pushing as each check
+    // settles, so anything reported below stays in document order.
+    const verdicts = await Promise.all(candidates.map(async img => {
+      if (img.complete && img.naturalWidth > 0) {
+        return "loaded"; // Loaded with intrinsic dimensions.
+      }
+      if (!img.complete) {
+        return "loading";
+      }
+      // Complete with a zero naturalWidth is ambiguous: a genuine load error
+      // (404/503) rejects decode(), while a valid but dimensionless image
+      // (such as an SVG with no intrinsic size) resolves it. Only the former
+      // should be re-requested; the latter is already settled.
+      try {
+        await img.decode();
+        return "loaded";
+      } catch {
+        return "errored";
+      }
+    }));
+    const pending = candidates.filter((img, index) => verdicts[index] !== "loaded");
+    const errored = candidates.filter((img, index) => verdicts[index] === "errored");
+    if (pending.length === 0) {
+      return [];
+    }
+    if (Date.now() >= deadline) {
+      return pending.map(img => {
+        const src = img.currentSrc || img.src;
+        try {
+          // Report the URL as the page authored it, without the cache-busting
+          // parameter a retry added, so the warning is greppable.
+          const url = new URL(src, location.href);
+          url.searchParams.delete("playwrightReload");
+          return url.href;
+        } catch {
+          return src;
+        }
+      });
+    }
+    // Re-request errored images, throttled so each retry has time to resolve.
+    if (Date.now() - lastReload > reloadIntervalMs) {
+      lastReload = Date.now();
+      errored.forEach(reload);
+    }
+    await new Promise(resolve => setTimeout(resolve, pollMs));
+  }
+}
+
+/**
+ * Wait for every visible image to finish decoding, recovering errored ones.
+ *
+ * See decodeVisibleImages() for how an image is judged loaded, broken, or
+ * merely dimensionless, and how broken ones are re-requested.
+ *
+ * Giving up is not an error: a page that legitimately references a missing
+ * image should still be screenshotted and still have its accessibility checked,
+ * and the screenshot comparison is what fails. But the wait is not silent
+ * either -- the images that never decoded are warned about, so a mysterious
+ * pixel diff (and the timeout's worth of delay before it) has an explanation --
+ * and they are returned so a caller can assert on them.
  *
  * @param page
  * @param timeoutMs How long to wait for images to decode before giving up.
+ * @returns The URLs of the images that never decoded. Empty when they all did.
  */
-export async function waitForImagesToDecode(page: Page, timeoutMs = 15000): Promise<void> {
-  await page.evaluate(async (timeout) => {
-    const deadline = Date.now() + timeout;
-    const isCandidate = (img: HTMLImageElement) => {
-      // Skip 1x1 visually-hidden images (see waitForImages above).
-      if (img.width <= 1 && img.height <= 1) {
-        return false;
-      }
-      const rect = img.getBoundingClientRect();
-      if (rect.width === 0 || rect.height === 0) {
-        return false;
-      }
-      const style = getComputedStyle(img);
-      return style.visibility !== "hidden" && style.display !== "none";
-    };
-    const reload = (img: HTMLImageElement) => {
-      const src = img.currentSrc || img.src;
-      if (!src || src.startsWith("data:")) {
-        return;
-      }
-      try {
-        const url = new URL(src, location.href);
-        url.searchParams.set("playwrightReload", String(Date.now()));
-        // Drop the responsive sources so the resolved URL we just loaded is the
-        // one fetched, instead of re-running srcset selection.
-        const picture = img.closest("picture");
-        if (picture) {
-          picture.querySelectorAll("source").forEach(source => source.remove());
-        }
-        img.removeAttribute("srcset");
-        img.src = url.href;
-      } catch {
-        // Ignore anything that is not a reloadable URL.
-      }
-    };
-
-    let lastReload = 0;
-    while (Date.now() < deadline) {
-      const candidates = Array.from(document.images).filter(isCandidate);
-      let pending = 0;
-      const errored: HTMLImageElement[] = [];
-      await Promise.all(candidates.map(async img => {
-        if (img.complete && img.naturalWidth > 0) {
-          return; // Loaded with intrinsic dimensions.
-        }
-        if (!img.complete) {
-          pending++; // Still loading.
-          return;
-        }
-        // Complete with a zero naturalWidth is ambiguous: a genuine load error
-        // (404/503) rejects decode(), while a valid but dimensionless image
-        // (such as an SVG with no intrinsic size) resolves it. Only the former
-        // should be re-requested; the latter is already settled.
-        try {
-          await img.decode();
-        } catch {
-          pending++;
-          errored.push(img);
-        }
-      }));
-      if (pending === 0) {
-        return;
-      }
-      // Re-request errored images, throttled so each retry has time to resolve.
-      if (Date.now() - lastReload > 2000) {
-        lastReload = Date.now();
-        errored.forEach(reload);
-      }
-      await new Promise(resolve => setTimeout(resolve, 250));
-    }
-  }, timeoutMs);
+export async function waitForImagesToDecode(page: Page, timeoutMs = 15000): Promise<string[]> {
+  const undecoded = await page.evaluate(decodeVisibleImages, {timeoutMs});
+  if (undecoded.length > 0) {
+    console.warn(
+      `waitForImagesToDecode: ${undecoded.length} image(s) did not finish loading within ${timeoutMs}ms and may be captured as broken: ${undecoded.join(', ')}`
+    );
+  }
+  return undecoded;
 }


### PR DESCRIPTION
waitForImagesToDecode() polled until its deadline and then returned exactly like the success path. A page with a permanently broken image cost every screenshot the full 15 second timeout and was then captured broken, with nothing in the output to explain either the delay or the resulting pixel diff.

The loop also tested the deadline before checking anything, so an already elapsed timeout -- waitForImagesToDecode(page, 0), or a deadline that passed while an earlier await ran -- reported success without looking at a single image.

Check the images first and test the deadline second, so every image is inspected at least once and the reported result reflects a check made at or after the deadline. Return the URLs that never decoded and warn about them. Giving up stays non-fatal: a page that legitimately references a missing image should still be screenshotted and still have its accessibility checked, which is also why takeAccessibleScreenshot() soft-fails the comparison.

Extract the browser-side polling into decodeVisibleImages() so it can be unit tested against a fake DOM. It stays self-contained, referencing only browser globals, so page.evaluate() can still serialize it.


Claude-Session: https://claude.ai/code/session_014c1uNovMUmZvtYkdrCXpyx