### PR TITLE
perf(test): drop redundant ddev restart after add-on install

### DIFF
--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -129,11 +129,13 @@ DOCKERFILE
     ddev restart >&3 2>&3
   fi
 
-  # Install the ddev-playwright add-on and restart.
+  # Install the ddev-playwright add-on. No restart here: `ddev install-playwright`
+  # below enables Dockerfile.playwright and does its own rebuild + restart, which
+  # picks up the add-on's Dockerfile.task and Dockerfile.uv in the same pass.
+  # Restarting now just pays for an extra container/router cycle, and its
+  # pre-start hook would copy a test/playwright directory that doesn't exist yet.
   echo "--- ddev add-on get Lullabot/ddev-playwright" >&3
   ddev add-on get Lullabot/ddev-playwright >&3 2>&3
-  echo "--- ddev restart" >&3
-  ddev restart >&3 2>&3
 
   # Initialize Playwright tests.
   mkdir -p test/playwright


### PR DESCRIPTION
`ddev install-playwright` enables Dockerfile.playwright and performs its own rebuild plus restart, which picks up the add-on's Dockerfile.task and Dockerfile.uv in the same pass. Restarting immediately after `add-on get` therefore buys nothing: the image layers it builds are reused by the very next rebuild, while the container stop/start and ddev-router recreate cycle is paid twice.

It was also running the add-on's pre-start hook against a test/playwright directory that does not exist yet, since `npx create-playwright` runs after this point.

Measured on CI run 31798911772, this restart cost roughly 35s in each of the three integration jobs, which are the critical path of the Test workflow.


Claude-Session: https://claude.ai/code/session_01QYXpNh6mPFRNzgiiwpJquc