### PR TITLE
ci: grant actions: read so the release workflow can start

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,11 @@ permissions:
   contents: write
   pull-requests: write
   id-token: write
+  # A called workflow cannot request more than its caller was granted, and an
+  # explicit block here denies everything it does not list. test.yml's
+  # failure-comment job asks for actions: read, so without this the whole run
+  # is rejected before any job starts and release-please never executes.
+  actions: read
 
 jobs:
   release-please:


### PR DESCRIPTION
The Release workflow calls test.yml as a reusable workflow. A called workflow cannot request a permission scope above what its caller was granted, and an explicit permissions block sets every scope it does not list to none.

test.yml's new failure-comment job requests actions: read for download-artifact, so GitHub rejected the entire run before scheduling any job — a 0s startup_failure — and release-please never executed. The job's `if: github.event_name == 'pull_request'` guard does not help: permissions are validated before `if` is evaluated.


Claude-Session: https://claude.ai/code/session_01Nk3j46yt3giN4fJUzG7T34