### PR TITLE
fix(github): read attachments written on the other side of a container

### DIFF
--- a/.github/actions/failure-summary/action.yml
+++ b/.github/actions/failure-summary/action.yml
@@ -40,6 +40,17 @@ inputs:
     description: Stop uploading after this many images.
     required: false
     default: '20'
+  path-prefix:
+    description: >-
+      `FROM:TO` mapping for the attachment paths in the report, for when
+      Playwright ran somewhere this step cannot reach — mapping
+      `/var/www/html` onto the checkout, for a DDEV project. Normally
+      unnecessary: the mapping is worked out by locating the recorded files
+      around the report, and confirmed against the disk before it is used. Set
+      it when that cannot work, such as a report moved away from the files it
+      describes.
+    required: false
+    default: ''
   package:
     description: >-
       Package to run the command from, resolved with npx — so a name, a version
@@ -60,6 +71,7 @@ runs:
         TITLE: ${{ inputs.title }}
         INCLUDE: ${{ inputs.include }}
         MAX_UPLOADS: ${{ inputs.max-uploads }}
+        PATH_PREFIX: ${{ inputs.path-prefix }}
         PACKAGE: ${{ inputs.package }}
       run: |
         # A missing report is not a failure: the suite may not have run.
@@ -76,6 +88,9 @@ runs:
         )
         if [ -n "${COMMENT_PATH}" ]; then
           args+=("--comment-path=${COMMENT_PATH}")
+        fi
+        if [ -n "${PATH_PREFIX}" ]; then
+          args+=("--path-prefix=${PATH_PREFIX}")
         fi
 
         # A checkout that has already been built can be run as it stands, which

--- a/docs/working-with-tests/screenshots-in-ci.md
+++ b/docs/working-with-tests/screenshots-in-ci.md
@@ -80,57 +80,6 @@ npx playwright-drupal-failure-summary --report-path=test-results/results.json
 It writes to `$GITHUB_STEP_SUMMARY`, or to stdout when run outside GitHub
 Actions.
 
-## Running Playwright in a container
-
-If your tests run in DDEV's web container — which is the arrangement this
-package is built for — the report and the images it points at are written from
-inside it. Every attachment path in the report is a container path,
-`/var/www/html/test/playwright/test-results/…`, and a workflow step reading
-that report on the runner is on the other side of the boundary. The report
-opens; the images it names do not exist.
-
-Nothing needs configuring for this. DDEV bind-mounts the project root at
-`/var/www/html`, so both views of a file agree on everything below the mount
-point and differ only above it. The mount point is found by hanging
-progressively longer tails of an unreadable path off the directories around the
-report until one of them names a file that is really there — longest tail
-first, so the most specific match wins, and never on the file name alone. Every
-mapping is confirmed against the disk before it is used, so a wrong guess finds
-nothing rather than the wrong image.
-
-The report's own `config` is deliberately not consulted for this. Its `rootDir`
-is the *test* directory rather than the project root, and `outputDir` need not
-contain the report, so neither reliably shares a tail with the path the report
-was read from.
-
-When that cannot work — a report copied somewhere unrelated to the checkout it
-describes, or a mount this cannot infer — say so directly:
-
-```yaml
-- uses: Lullabot/playwright-drupal/.github/actions/failure-summary@main
-  with:
-    report-path: test/playwright/test-results/results.json
-    path-prefix: /var/www/html:${{ github.workspace }}
-```
-
-Running the command inside the container instead also works, and is what the
-accessibility action does. It needs one extra step: `$GITHUB_STEP_SUMMARY` is a
-runner-side path the container cannot write to, so the summary has to be piped
-to it from the host shell.
-
-!!! warning "Do not symlink `/var/www/html` on the runner"
-
-    It looks like it should work and it does not. The Ubuntu runner image ships
-    Apache, so `/var/www/html` already exists as a directory, and `ln -sfn`
-    quietly creates the link *inside* it. The command exits 0 and changes
-    nothing.
-
-Only snapshot comparison images are affected, which is why this can look like a
-feature that works. Accessibility screenshots are attached as a body rather
-than a file, and Playwright's JSON reporter inlines those as base64 — they
-travel inside the report and never touch a path. The `-diff`, `-actual` and
-`-expected` images are the only attachments carrying one.
-
 ## The upload token
 
 Embedding images means uploading them to GitHub first, and that upload is the

--- a/docs/working-with-tests/screenshots-in-ci.md
+++ b/docs/working-with-tests/screenshots-in-ci.md
@@ -80,6 +80,57 @@ npx playwright-drupal-failure-summary --report-path=test-results/results.json
 It writes to `$GITHUB_STEP_SUMMARY`, or to stdout when run outside GitHub
 Actions.
 
+## Running Playwright in a container
+
+If your tests run in DDEV's web container — which is the arrangement this
+package is built for — the report and the images it points at are written from
+inside it. Every attachment path in the report is a container path,
+`/var/www/html/test/playwright/test-results/…`, and a workflow step reading
+that report on the runner is on the other side of the boundary. The report
+opens; the images it names do not exist.
+
+Nothing needs configuring for this. DDEV bind-mounts the project root at
+`/var/www/html`, so both views of a file agree on everything below the mount
+point and differ only above it. The mount point is found by hanging
+progressively longer tails of an unreadable path off the directories around the
+report until one of them names a file that is really there — longest tail
+first, so the most specific match wins, and never on the file name alone. Every
+mapping is confirmed against the disk before it is used, so a wrong guess finds
+nothing rather than the wrong image.
+
+The report's own `config` is deliberately not consulted for this. Its `rootDir`
+is the *test* directory rather than the project root, and `outputDir` need not
+contain the report, so neither reliably shares a tail with the path the report
+was read from.
+
+When that cannot work — a report copied somewhere unrelated to the checkout it
+describes, or a mount this cannot infer — say so directly:
+
+```yaml
+- uses: Lullabot/playwright-drupal/.github/actions/failure-summary@main
+  with:
+    report-path: test/playwright/test-results/results.json
+    path-prefix: /var/www/html:${{ github.workspace }}
+```
+
+Running the command inside the container instead also works, and is what the
+accessibility action does. It needs one extra step: `$GITHUB_STEP_SUMMARY` is a
+runner-side path the container cannot write to, so the summary has to be piped
+to it from the host shell.
+
+!!! warning "Do not symlink `/var/www/html` on the runner"
+
+    It looks like it should work and it does not. The Ubuntu runner image ships
+    Apache, so `/var/www/html` already exists as a directory, and `ln -sfn`
+    quietly creates the link *inside* it. The command exits 0 and changes
+    nothing.
+
+Only snapshot comparison images are affected, which is why this can look like a
+feature that works. Accessibility screenshots are attached as a body rather
+than a file, and Playwright's JSON reporter inlines those as base64 — they
+travel inside the report and never touch a path. The `-diff`, `-actual` and
+`-expected` images are the only attachments carrying one.
+
 ## The upload token
 
 Embedding images means uploading them to GitHub first, and that upload is the
@@ -211,6 +262,7 @@ The action inputs map onto the command's flags.
 | `--title` | `title` | `Playwright results` | Heading for the comment. |
 | `--include` | `include` | `diff` | `diff` uploads only the diff image; `all` adds the expected and actual images. Accessibility screenshots are included either way. |
 | `--max-uploads` | `max-uploads` | `20` | Stop uploading after this many images. |
+| `--path-prefix` | `path-prefix` | derived | `FROM:TO` for attachment paths written on the other side of a container boundary. Repeatable on the command line. |
 | — | `token` | none | The upload token. Without it, no images. |
 | — | `artifact-name` | none | Upload the comment body under this artifact name. |
 | — | `package` | `@lullabot/playwright-drupal` | Where to run the command from. |
@@ -224,6 +276,13 @@ switches uploading off for the rest of the run rather than retrying against
 something that is not there, and the reason is logged. The summary and comment
 are still written; they point at the artifact instead of showing images.
 Nothing about this can fail a build.
+
+Whatever the cause, the rendered output says which one it was. "No upload token
+configured" and "3 could not be read from the path recorded in the report" are
+different problems with different fixes, and a summary that only said images
+were missing left no way to tell them apart. An unreachable attachment also
+raises a `::warning::` on the job, because it is a misconfiguration rather than
+a fact of life like an absent token on a fork build.
 
 One consequence of how the endpoint works is worth stating plainly: the URL it
 returns cannot be fetched. It is a handle that only GitHub's Markdown renderer

--- a/src/github/failure-summary.test.ts
+++ b/src/github/failure-summary.test.ts
@@ -4,12 +4,14 @@ import * as os from 'os'
 import * as path from 'path'
 import {
   parseFailures,
+  resolveImagePaths,
   generateSummary,
   generateComment,
   uploadImages,
   defuseMaskTriggers,
   FailureReport,
 } from './failure-summary'
+import { createPathResolver } from './report-paths'
 import { AttachmentUploader, FetchLike } from './attachments'
 
 let tmpDir: string
@@ -171,6 +173,33 @@ describe('generateSummary', () => {
     expect(summary).toContain('not uploaded')
   })
 
+  it('says an absent token is why nothing was uploaded', () => {
+    const summary = generateSummary(reportWith(undefined), {
+      uploadReason: 'no upload token configured',
+    })
+
+    expect(summary).toContain('not uploaded (no upload token configured)')
+  })
+
+  it('says so when the images were not where the report said they were', () => {
+    // The reason a reader most needs, and the one that used to be silent: the
+    // token is fine, the files are on the other side of a container boundary.
+    const report = reportWith(undefined)
+    report.tests[0].images[0].filePath = '/var/www/html/test/playwright/test-results/home-1-diff.png'
+    report.tests[0].images[0].unreadable = true
+
+    const summary = generateSummary(report)
+
+    expect(summary).toContain('1 screenshot(s) could not be read')
+    expect(summary).toContain('/var/www/html/test/playwright/test-results/home-1-diff.png')
+    expect(summary).toContain('--path-prefix=')
+    expect(summary).toContain('not uploaded (1 could not be read')
+  })
+
+  it('does not mention a path boundary when there is none', () => {
+    expect(generateSummary(reportWith(undefined))).not.toContain('could not be read')
+  })
+
   it('does not claim zero failing tests when only a11y captured something', () => {
     const summary = generateSummary({
       tests: [{
@@ -230,6 +259,28 @@ describe('generateComment', () => {
     expect(comment).toContain('**1** failing test(s)')
     expect(comment).toContain('homepage matches')
     expect(comment).toContain('(https://example.test/run/1)')
+  })
+
+  it('says why the screenshots it promised are not there', () => {
+    // The bullet list still advertises the screenshots, so a comment with no
+    // images has to account for them or it reads as a broken feature.
+    const comment = generateComment(report, { uploadReason: 'no upload token configured' })
+
+    expect(comment).toContain('1 screenshot(s) not shown — no upload token configured')
+  })
+
+  it('distinguishes unreadable images from an absent token', () => {
+    const unreadable: FailureReport = {
+      ...report,
+      tests: [{
+        ...report.tests[0],
+        images: [{ ...report.tests[0].images[0], unreadable: true }],
+      }],
+    }
+
+    const comment = generateComment(unreadable)
+
+    expect(comment).toContain('1 could not be read from the path recorded in the report')
   })
 
   it('embeds uploaded images in a collapsed block', () => {
@@ -299,6 +350,98 @@ describe('defuseMaskTriggers', () => {
 
   it('leaves the bare word alone, which the runner does not redact', () => {
     expect(defuseMaskTriggers('Bearer')).toBe('Bearer')
+  })
+})
+
+describe('resolveImagePaths', () => {
+  /**
+   * A report as it arrives from a run inside DDEV: every path absolute and
+   * under /var/www/html, read from a checkout that has no such directory.
+   */
+  function containerRun(diffPath: string) {
+    const raw = {
+      config: {
+        // What Playwright actually records: the *test* directory, which is why
+        // the report's own config is no use for locating the mount point.
+        rootDir: '/var/www/html/test/playwright/tests',
+        projects: [{ name: 'chromium', outputDir: '/var/www/html/test/playwright/test-results' }],
+      },
+      suites: [{
+        title: '',
+        file: 'tests/visual.spec.ts',
+        specs: [{
+          title: 'homepage matches',
+          line: 10,
+          tests: [{
+            results: [{
+              status: 'failed',
+              attachments: [{ name: 'homepage-1-diff.png', contentType: 'image/png', path: diffPath }],
+            }],
+          }],
+        }],
+      }],
+    }
+
+    const reportPath = path.join(tmpDir, 'test/playwright/test-results/results.json')
+    fs.mkdirSync(path.dirname(reportPath), { recursive: true })
+    fs.writeFileSync(reportPath, JSON.stringify(raw))
+
+    return reportPath
+  }
+
+  it('finds a diff image written by a container and read from outside it', () => {
+    // The bind mount that makes the two views differ also makes this work:
+    // the same file is under the checkout, at a different prefix.
+    const diffPath = path.join(tmpDir, 'test/playwright/test-results/homepage-chromium/homepage-1-diff.png')
+    fs.mkdirSync(path.dirname(diffPath), { recursive: true })
+    fs.writeFileSync(diffPath, 'png')
+
+    const reportPath = containerRun(
+      '/var/www/html/test/playwright/test-results/homepage-chromium/homepage-1-diff.png',
+    )
+    const report = parseFailures(reportPath)
+
+    const summary = resolveImagePaths(report, createPathResolver({ reportPath }))
+
+    expect(summary.unreadable).toEqual([])
+    expect(summary.remapped).toBe(1)
+    expect(summary.used).toEqual([{ from: '/var/www/html', to: tmpDir }])
+    expect(report.tests[0].images[0].filePath).toBe(diffPath)
+    expect(report.tests[0].images[0].unreadable).toBeUndefined()
+  })
+
+  it('marks an image it cannot reach, rather than passing the path on', () => {
+    const reportPath = containerRun(
+      '/var/www/html/test/playwright/test-results/never-written/never-written-diff.png',
+    )
+    const report = parseFailures(reportPath)
+
+    const summary = resolveImagePaths(report, createPathResolver({ reportPath }))
+
+    expect(summary.remapped).toBe(0)
+    expect(summary.unreadable).toEqual([
+      '/var/www/html/test/playwright/test-results/never-written/never-written-diff.png',
+    ])
+    expect(report.tests[0].images[0].unreadable).toBe(true)
+  })
+
+  it('leaves an inlined accessibility screenshot alone', () => {
+    // These carry a body rather than a path, which is why they were the one
+    // attachment kind that never hit the boundary.
+    const report = parseFailures(writeReport([{
+      title: 'homepage a11y',
+      status: 'failed',
+      attachments: [{
+        name: 'a11y-violation-screenshot',
+        contentType: 'image/png',
+        body: 'aGVsbG8=',
+      }],
+    }]))
+
+    const summary = resolveImagePaths(report, createPathResolver({ reportPath: '/nowhere/results.json' }))
+
+    expect(summary).toEqual({ remapped: 0, used: [], unreadable: [] })
+    expect(report.tests[0].images[0].body).toBe('aGVsbG8=')
   })
 })
 

--- a/src/github/failure-summary.ts
+++ b/src/github/failure-summary.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import { AttachmentUploader, AttachmentUploaderOptions } from './attachments'
+import { PathPrefix, PathResolution, createPathResolver, parsePathPrefix } from './report-paths'
 
 /**
  * Turn a Playwright JSON report into a job summary — and optionally a PR
@@ -45,6 +46,12 @@ export interface FailureImage {
   kind: ImageKind
   /** Populated once the image has been uploaded. */
   url?: string
+  /**
+   * Set when the recorded path could not be found on this side of a container
+   * boundary. Distinguishes "there was nothing to upload with" from "there was
+   * nowhere to upload to", which otherwise render identically.
+   */
+  unreadable?: boolean
 }
 
 export interface FailedTest {
@@ -187,6 +194,56 @@ export function parseFailures(reportPath: string, include: IncludeMode = 'diff')
   return { tests, totalFailed, totalImages }
 }
 
+/** What re-rooting the report's attachment paths achieved. */
+export interface PathResolutionSummary {
+  /** Attachments whose recorded path had to be rewritten to be readable. */
+  remapped: number
+  /** The mappings that were used, for the log line. */
+  used: PathPrefix[]
+  /** Recorded paths with no readable file behind them, on either side. */
+  unreadable: string[]
+}
+
+/**
+ * Point every image at a file this process can open, and note the ones where
+ * that was not possible.
+ *
+ * Runs whether or not uploads are switched on: an unreachable attachment is
+ * worth reporting even on a fork build that was never going to upload it,
+ * because it is the same misconfiguration either way.
+ */
+export function resolveImagePaths(
+  report: FailureReport,
+  resolve: (filePath: string) => PathResolution,
+): PathResolutionSummary {
+  const summary: PathResolutionSummary = { remapped: 0, used: [], unreadable: [] }
+
+  for (const test of report.tests) {
+    for (const image of test.images) {
+      if (!image.filePath) continue
+
+      const resolution = resolve(image.filePath)
+      if (!resolution.found) {
+        image.unreadable = true
+        summary.unreadable.push(image.filePath)
+        continue
+      }
+
+      if (resolution.path === image.filePath) continue
+
+      summary.remapped++
+      image.filePath = resolution.path
+
+      const prefix = resolution.prefix
+      if (prefix && !summary.used.some(used => used.from === prefix.from && used.to === prefix.to)) {
+        summary.used.push(prefix)
+      }
+    }
+  }
+
+  return summary
+}
+
 /**
  * Upload every collected image, annotating each one with its URL. Images the
  * uploader declines are simply left without a URL, which the renderers treat
@@ -202,6 +259,9 @@ export async function uploadImages(
 
       if (image.filePath) {
         url = await uploader.upload(image.filePath, path.basename(image.filePath))
+        // resolveImagePaths() has already checked the file is there, so a null
+        // from an uploader that is still running means the read itself failed.
+        if (!url && uploader.enabled) image.unreadable = true
       } else if (image.body) {
         url = await uploader.uploadBuffer(
           Buffer.from(image.body, 'base64'),
@@ -237,6 +297,37 @@ function headline(report: FailureReport): string {
   return parts.join(' · ')
 }
 
+/** Every image across every test, which is what the diagnostics count. */
+function allImages(report: FailureReport): FailureImage[] {
+  return report.tests.flatMap(test => test.images)
+}
+
+/**
+ * Say why a set of images was not uploaded, or nothing when they were.
+ *
+ * "No token" and "the files were not where the report said" are different
+ * problems with different fixes, and until they are named apart a reader has
+ * no way to tell which one they have. An absent token is the dominant reason
+ * when it applies: nothing was going to be uploaded regardless.
+ */
+function missingImageReason(images: FailureImage[], uploadReason?: string): string | undefined {
+  if (uploadReason) return uploadReason
+
+  const unreadable = images.filter(image => image.unreadable).length
+  if (unreadable === 0) return undefined
+
+  return `${unreadable} could not be read from the path recorded in the report`
+}
+
+export interface SummaryOptions {
+  artifactHint?: string
+  /**
+   * Why uploading did not happen at all, phrased to sit inside a sentence —
+   * `no upload token configured`, say. Leave unset when uploads ran.
+   */
+  uploadReason?: string
+}
+
 /**
  * Render the job summary: a heading, a headline, and one collapsed block per
  * test holding its images.
@@ -244,13 +335,26 @@ function headline(report: FailureReport): string {
  * Deliberately table-free. Test titles and error messages are arbitrary text,
  * and the runner's masking can eat a cell delimiter and corrupt a whole row.
  */
-export function generateSummary(report: FailureReport, options: { artifactHint?: string } = {}): string {
+export function generateSummary(report: FailureReport, options: SummaryOptions = {}): string {
   // A baselined accessibility violation is screenshotted without failing
   // anything, so a green run can still have something to show here.
   const heading = report.totalFailed > 0 ? '## Test Failures' : '## Test Screenshots'
   const lines: string[] = [`${heading}\n`, `${headline(report)}\n`]
 
   if (report.tests.length === 0) return lines.join('\n')
+
+  // Name the path boundary where it will be read, rather than leaving the
+  // reader to conclude they forgot the token.
+  const unreadable = allImages(report).filter(image => image.unreadable)
+  if (unreadable.length > 0) {
+    const example = defuseMaskTriggers(unreadable[0].filePath ?? '')
+    lines.push(
+      `> :warning: **${unreadable.length} screenshot(s) could not be read.** The report records them ` +
+      `under \`${example}\`, which does not exist where this step ran. Playwright ran somewhere else — ` +
+      'a container, most likely — so run this command there too, or pass ' +
+      '`--path-prefix=CONTAINER_PATH:LOCAL_PATH` to map one onto the other.\n',
+    )
+  }
 
   for (const test of report.tests) {
     const title = defuseMaskTriggers(test.title)
@@ -272,7 +376,9 @@ export function generateSummary(report: FailureReport, options: { artifactHint?:
       lines.push(`${embedded} screenshot(s) uploaded — see the pull request comment.\n`)
     } else {
       const hint = options.artifactHint ?? 'the Playwright report artifact'
-      lines.push(`${test.images.length} screenshot(s) captured, not uploaded — download ${hint}.\n`)
+      const reason = missingImageReason(test.images, options.uploadReason)
+      const because = reason ? ` (${reason})` : ''
+      lines.push(`${test.images.length} screenshot(s) captured, not uploaded${because} — download ${hint}.\n`)
     }
   }
 
@@ -311,7 +417,7 @@ function renderImageBlock(test: FailedTest): string[] {
  */
 export function generateComment(
   report: FailureReport,
-  options: { summaryUrl?: string; title?: string } = {},
+  options: { summaryUrl?: string; title?: string; uploadReason?: string } = {},
 ): string {
   const heading = options.title ?? 'Playwright results'
   const lines: string[] = [`### ${heading}\n`, `${headline(report)}\n`]
@@ -332,6 +438,14 @@ export function generateComment(
       if (block.length === 0) continue
       lines.push(`**${defuseMaskTriggers(test.title)}**\n`)
       lines.push(...block)
+    }
+
+    // An empty comment where images were expected reads as a broken feature.
+    // Whatever the reason, it belongs where the images would have been.
+    const missing = allImages(report).filter(image => !image.url)
+    const reason = missingImageReason(missing, options.uploadReason)
+    if (missing.length > 0 && reason) {
+      lines.push(`_${missing.length} screenshot(s) not shown — ${reason}._\n`)
     }
   }
 
@@ -357,15 +471,26 @@ interface CliOptions {
   include: IncludeMode
   maxUploads?: number
   title?: string
+  pathPrefixes: PathPrefix[]
 }
 
 function parseArgs(args: string[]): CliOptions {
   const options: CliOptions = {
     reportPath: 'test-results/results.json',
     include: 'diff',
+    pathPrefixes: [],
   }
 
   for (const arg of args) {
+    // Repeatable: a project can have more than one mount to translate.
+    if (arg.startsWith('--path-prefix=')) {
+      const prefix = parsePathPrefix(arg.slice('--path-prefix='.length))
+      if (prefix) {
+        options.pathPrefixes.push(prefix)
+      } else {
+        console.error(`Ignoring --path-prefix: expected FROM:TO, got ${arg.slice('--path-prefix='.length)}`)
+      }
+    }
     if (arg.startsWith('--report-path=')) options.reportPath = arg.slice('--report-path='.length)
     if (arg.startsWith('--comment-path=')) options.commentPath = arg.slice('--comment-path='.length)
     if (arg.startsWith('--title=')) options.title = arg.slice('--title='.length)
@@ -380,6 +505,28 @@ function parseArgs(args: string[]): CliOptions {
   }
 
   return options
+}
+
+/**
+ * Raise a warning where someone will see it.
+ *
+ * A `::warning::` command has to go to stdout for the runner to pick it up,
+ * which is only safe once the summary itself is going to a file — otherwise it
+ * would land in the middle of the Markdown. Outside Actions, or when the
+ * summary is on stdout, stderr is the only sensible place.
+ */
+function warn(message: string): void {
+  const inActions = process.env.GITHUB_ACTIONS === 'true' && !!process.env.GITHUB_STEP_SUMMARY
+  if (inActions) {
+    process.stdout.write(`::warning title=Playwright screenshots::${escapeAnnotation(message)}\n`)
+  } else {
+    console.error(`Warning: ${message}`)
+  }
+}
+
+/** Workflow commands are line-based, so anything that ends a line is encoded. */
+function escapeAnnotation(message: string): string {
+  return message.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A')
 }
 
 /** Build the run's job summary URL, which is the best anchor a comment can link to. */
@@ -416,6 +563,25 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
 
   const report = parseFailures(resolvedPath, options.include)
 
+  // The report records where the run wrote its attachments, which is not
+  // necessarily anywhere this process can reach. Settle that before uploading,
+  // so an unreachable file is reported as one rather than as a silent skip.
+  const paths = resolveImagePaths(
+    report,
+    createPathResolver({ reportPath: resolvedPath, prefixes: options.pathPrefixes }),
+  )
+  if (paths.remapped > 0) {
+    const mappings = paths.used.map(prefix => `${prefix.from} → ${prefix.to}`).join(', ')
+    console.error(`Remapped ${paths.remapped} attachment path(s): ${mappings || 'no mapping recorded'}`)
+  }
+  if (paths.unreadable.length > 0) {
+    warn(
+      `${paths.unreadable.length} screenshot(s) could not be read, starting with ${paths.unreadable[0]}. ` +
+      'Playwright ran somewhere this command cannot reach — a container, most likely. Run it there too, ' +
+      'or pass --path-prefix=CONTAINER_PATH:LOCAL_PATH.',
+    )
+  }
+
   const uploader = uploaderFromEnvironment(
     options.maxUploads === undefined ? {} : { maxUploads: options.maxUploads },
   )
@@ -424,13 +590,16 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
     const stats = uploader.getStats()
     console.error(`Uploaded ${stats.uploaded} screenshot(s), skipped ${stats.skipped}.`)
     if (uploader.disabledReason) {
-      console.error(`Uploads stopped early — ${uploader.disabledReason}.`)
+      // Reaching an undocumented endpoint that no longer answers is a real
+      // fault, unlike an absent token on a fork build.
+      warn(`Screenshot uploads stopped early — ${uploader.disabledReason}.`)
     }
   } else {
     console.error(`Screenshot uploads are off — ${uploader.disabledReason}.`)
   }
 
-  const summary = generateSummary(report)
+  const uploadReason = uploader.disabledReason ?? undefined
+  const summary = generateSummary(report, { uploadReason })
   const summaryFile = process.env.GITHUB_STEP_SUMMARY
   if (summaryFile) {
     fs.appendFileSync(summaryFile, summary)
@@ -440,7 +609,11 @@ export async function main(args: string[] = process.argv.slice(2)): Promise<void
   }
 
   if (options.commentPath) {
-    const comment = generateComment(report, { summaryUrl: summaryUrl(), title: options.title })
+    const comment = generateComment(report, {
+      summaryUrl: summaryUrl(),
+      title: options.title,
+      uploadReason,
+    })
     fs.writeFileSync(path.resolve(options.commentPath), comment)
     console.error(`Comment body written to ${options.commentPath}`)
   }

--- a/src/github/report-paths.test.ts
+++ b/src/github/report-paths.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+import { createPathResolver, parsePathPrefix } from './report-paths'
+
+let tmpDir: string
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'report-paths-test-'))
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Create a file, and every directory above it, under the temporary directory. */
+function touch(relativePath: string): string {
+  const filePath = path.join(tmpDir, relativePath)
+  fs.mkdirSync(path.dirname(filePath), { recursive: true })
+  fs.writeFileSync(filePath, 'png')
+  return filePath
+}
+
+describe('parsePathPrefix', () => {
+  it('splits on the first colon', () => {
+    expect(parsePathPrefix('/var/www/html:/home/runner/work/site/site')).toEqual({
+      from: '/var/www/html',
+      to: '/home/runner/work/site/site',
+    })
+  })
+
+  it('keeps a colon in the local path, as Windows drives have', () => {
+    expect(parsePathPrefix('/var/www/html:C:/checkout')).toEqual({
+      from: '/var/www/html',
+      to: 'C:/checkout',
+    })
+  })
+
+  it('rejects a value that is not a pair', () => {
+    expect(parsePathPrefix('/var/www/html')).toBeNull()
+    expect(parsePathPrefix(':/home/runner')).toBeNull()
+    expect(parsePathPrefix('/var/www/html:')).toBeNull()
+  })
+})
+
+describe('createPathResolver', () => {
+  it('leaves a path that already resolves alone', () => {
+    const filePath = touch('test/playwright/test-results/diff.png')
+    const resolve = createPathResolver({ reportPath: path.join(tmpDir, 'results.json') })
+
+    expect(resolve(filePath)).toEqual({ path: filePath, found: true })
+  })
+
+  it('re-roots a container path onto the checkout', () => {
+    touch('test/playwright/test-results/home-chromium/home-1-diff.png')
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'test/playwright/test-results/results.json'),
+    })
+
+    const resolution = resolve(
+      '/var/www/html/test/playwright/test-results/home-chromium/home-1-diff.png',
+    )
+
+    expect(resolution.found).toBe(true)
+    expect(resolution.path)
+      .toBe(path.join(tmpDir, 'test/playwright/test-results/home-chromium/home-1-diff.png'))
+    expect(resolution.prefix).toEqual({ from: '/var/www/html', to: tmpDir })
+  })
+
+  it('finds the files when the report sits outside the output directory', () => {
+    // The arrangement the integration test produces: the report is written
+    // beside the Playwright config while the images go to a separate output
+    // directory, so the two share nothing but the mount point.
+    touch('test/playwright/test-results-visual/fixture-chromium/fixture-diff.png')
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'test/playwright/visual-diff-results.json'),
+    })
+
+    const resolution = resolve(
+      '/var/www/html/test/playwright/test-results-visual/fixture-chromium/fixture-diff.png',
+    )
+
+    expect(resolution.found).toBe(true)
+    expect(resolution.path)
+      .toBe(path.join(tmpDir, 'test/playwright/test-results-visual/fixture-chromium/fixture-diff.png'))
+  })
+
+  it('does not assume a fixed offset between the report and the mount point', () => {
+    // This repository's own CI creates the project under a generated directory,
+    // so its depth below the workspace differs from the container's.
+    touch('tmp/pwtest-abc123/test/playwright/test-results/home-chromium/home-1-diff.png')
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'tmp/pwtest-abc123/test/playwright/test-results/results.json'),
+    })
+
+    const resolution = resolve(
+      '/var/www/html/test/playwright/test-results/home-chromium/home-1-diff.png',
+    )
+
+    expect(resolution.found).toBe(true)
+    expect(resolution.prefix).toEqual({
+      from: '/var/www/html',
+      to: path.join(tmpDir, 'tmp/pwtest-abc123'),
+    })
+  })
+
+  it('prefers the longest tail, so the most specific match wins', () => {
+    // A shallow decoy sharing the last two components must not beat the real
+    // file, which shares many more.
+    touch('decoy/fixture-chromium/fixture-diff.png')
+    touch('test/playwright/test-results/fixture-chromium/fixture-diff.png')
+
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'test/playwright/test-results/results.json'),
+    })
+
+    expect(resolve('/var/www/html/test/playwright/test-results/fixture-chromium/fixture-diff.png').path)
+      .toBe(path.join(tmpDir, 'test/playwright/test-results/fixture-chromium/fixture-diff.png'))
+  })
+
+  it('will not identify a file by its name alone', () => {
+    // One component of tail is a coincidence waiting to happen: some unrelated
+    // fixture-diff.png must not be served up as the failure's diff image.
+    touch('fixture-diff.png')
+    const resolve = createPathResolver({ reportPath: path.join(tmpDir, 'results.json') })
+
+    expect(resolve('/var/www/html/somewhere/else/fixture-diff.png').found).toBe(false)
+  })
+
+  it('reports a path it cannot find rather than inventing one', () => {
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'test/playwright/test-results/results.json'),
+    })
+
+    const resolution = resolve('/var/www/html/test/playwright/test-results/missing-diff.png')
+
+    expect(resolution).toEqual({
+      path: '/var/www/html/test/playwright/test-results/missing-diff.png',
+      found: false,
+    })
+  })
+
+  it('reuses a mapping it has already worked out', () => {
+    touch('test-results/one/a-diff.png')
+    touch('test-results/two/b-diff.png')
+
+    const looked: string[] = []
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'results.json'),
+      exists: filePath => {
+        looked.push(filePath)
+        return fs.existsSync(filePath)
+      },
+    })
+
+    resolve('/var/www/html/test-results/one/a-diff.png')
+    const afterFirst = looked.length
+    looked.length = 0
+
+    expect(resolve('/var/www/html/test-results/two/b-diff.png').found).toBe(true)
+    // The learned mapping is tried straight after the original path, rather
+    // than searching the tree again.
+    expect(looked.length).toBeLessThan(afterFirst)
+    expect(looked).toEqual([
+      '/var/www/html/test-results/two/b-diff.png',
+      path.join(tmpDir, 'test-results/two/b-diff.png'),
+    ])
+  })
+
+  it('prefers an explicit prefix over anything it would work out', () => {
+    touch('elsewhere/test-results/home-1-diff.png')
+    touch('test/playwright/test-results/home-1-diff.png')
+
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'test/playwright/test-results/results.json'),
+      prefixes: [{ from: '/var/www/html/test/playwright', to: path.join(tmpDir, 'elsewhere') }],
+    })
+
+    expect(resolve('/var/www/html/test/playwright/test-results/home-1-diff.png').path)
+      .toBe(path.join(tmpDir, 'elsewhere/test-results/home-1-diff.png'))
+  })
+
+  it('ignores a prefix the path is not under', () => {
+    touch('test-results/diff.png')
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'results.json'),
+      prefixes: [{ from: '/somewhere/else', to: tmpDir }],
+    })
+
+    // The explicit prefix does not apply, and one component of tail is too
+    // little to search on.
+    expect(resolve('/var/www/html/diff.png').found).toBe(false)
+  })
+
+  it('does not match a prefix part way through a directory name', () => {
+    touch('results/diff.png')
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'results.json'),
+      prefixes: [{ from: '/var/www/ht', to: tmpDir }],
+    })
+
+    // /var/www/html starts with the string /var/www/ht but is not under it,
+    // so the explicit mapping must not fire. The search still finds the file.
+    const resolution = resolve('/var/www/html/results/diff.png')
+    expect(resolution.path).toBe(path.join(tmpDir, 'results/diff.png'))
+    expect(resolution.prefix).toEqual({ from: '/var/www/html', to: tmpDir })
+  })
+
+  it('tolerates a trailing slash on the local side', () => {
+    touch('test-results/diff.png')
+    const resolve = createPathResolver({
+      reportPath: path.join(tmpDir, 'results.json'),
+      prefixes: [{ from: '/var/www/html', to: `${tmpDir}/` }],
+    })
+
+    expect(resolve('/var/www/html/test-results/diff.png').path)
+      .toBe(`${tmpDir}/test-results/diff.png`)
+  })
+})

--- a/src/github/report-paths.test.ts
+++ b/src/github/report-paths.test.ts
@@ -207,11 +207,13 @@ describe('createPathResolver', () => {
     expect(resolution.prefix).toEqual({ from: '/var/www/html', to: tmpDir })
   })
 
-  it('tolerates a trailing slash on the local side', () => {
+  it('tolerates trailing slashes on the local side', () => {
     touch('test-results/diff.png')
     const resolve = createPathResolver({
       reportPath: path.join(tmpDir, 'results.json'),
-      prefixes: [{ from: '/var/www/html', to: `${tmpDir}/` }],
+      // A run of them, not just one: the trim is an index scan rather than a
+      // regex, because `/[\\/]+$/` backtracks quadratically over exactly this.
+      prefixes: [{ from: '/var/www/html', to: `${tmpDir}///` }],
     })
 
     expect(resolve('/var/www/html/test-results/diff.png').path)

--- a/src/github/report-paths.ts
+++ b/src/github/report-paths.ts
@@ -25,6 +25,11 @@ import * as path from 'path'
  * `config` is deliberately not consulted: `rootDir` is the *test* directory
  * rather than the project root, and `outputDir` need not contain the report,
  * so neither reliably shares a tail with the path the report was read from.
+ *
+ * Symlinking the container path on the runner instead looks like it should
+ * work and does not: the Ubuntu runner image ships Apache, so /var/www/html
+ * already exists as a directory and `ln -sfn` quietly creates the link inside
+ * it. The command exits 0 and changes nothing.
  */
 
 /**

--- a/src/github/report-paths.ts
+++ b/src/github/report-paths.ts
@@ -110,7 +110,7 @@ export function createPathResolver(
       const tail = target.components.slice(target.components.length - length).join('/')
 
       for (const root of searchRoots) {
-        const candidate = `${root.replace(/[\\/]+$/, '')}/${tail}`
+        const candidate = `${trimTrailingSeparators(root)}/${tail}`
         if (!exists(candidate)) continue
 
         return {
@@ -151,8 +151,21 @@ function applyPrefix(filePath: string, prefix: PathPrefix): string | null {
   }
 
   const rest = target.components.slice(from.components.length)
-  const to = prefix.to.replace(/[\\/]+$/, '')
+  const to = trimTrailingSeparators(prefix.to)
   return rest.length === 0 ? to : `${to}/${rest.join('/')}`
+}
+
+/**
+ * Trim trailing separators.
+ *
+ * An index scan rather than `/[\\/]+$/`, because that pattern backtracks
+ * quadratically over a long run of separators — and these strings are paths
+ * out of a report this package did not write.
+ */
+function trimTrailingSeparators(value: string): string {
+  let end = value.length
+  while (end > 0 && (value[end - 1] === '/' || value[end - 1] === '\\')) end--
+  return value.slice(0, end)
 }
 
 interface SplitPath {

--- a/src/github/report-paths.ts
+++ b/src/github/report-paths.ts
@@ -1,0 +1,190 @@
+import * as fs from 'fs'
+import * as path from 'path'
+
+/**
+ * Translate the file paths a Playwright JSON report records into paths the
+ * process reading that report can actually open.
+ *
+ * The two are not always the same file system. Running Playwright inside a
+ * container — which is the normal arrangement for this package, where the suite
+ * runs in DDEV's web container — records every attachment under the path it had
+ * *there*, `/var/www/html/…`. A workflow step reading the report on the runner
+ * is on the other side of that boundary, and `/var/www/html` means nothing to
+ * it. The report is readable, the attachments are not, and nothing about the
+ * failure says why.
+ *
+ * The bind mount that creates the problem also solves it: the same files are
+ * visible from both sides under different prefixes, so the paths need
+ * re-rooting rather than fetching. What the two views share is the tail of the
+ * path — the part below the mount point — so the mount point is found by
+ * hanging progressively longer tails of a recorded path off the directories
+ * around the report until one of them names a file that exists.
+ *
+ * Every mapping is confirmed against the disk before it is used, so a wrong
+ * guess resolves to nothing rather than to the wrong image. The report's own
+ * `config` is deliberately not consulted: `rootDir` is the *test* directory
+ * rather than the project root, and `outputDir` need not contain the report,
+ * so neither reliably shares a tail with the path the report was read from.
+ */
+
+/**
+ * Shortest tail worth trying, in path components.
+ *
+ * A bare file name is too little to identify a file by — some unrelated
+ * `fixture-diff.png` elsewhere in the tree would match. One directory of
+ * context makes a coincidence unlikely, and longer tails are tried first
+ * regardless, so the most specific match always wins.
+ */
+const MIN_TAIL_COMPONENTS = 2
+
+export interface PathPrefix {
+  /** Absolute path as recorded in the report — typically a container path. */
+  from: string
+  /** The same directory as seen from here. */
+  to: string
+}
+
+export interface PathResolution {
+  /** The path to read. Unchanged when the recorded one was already fine. */
+  path: string
+  /** Whether a readable file was found. */
+  found: boolean
+  /** The mapping that made it readable, when one was needed. */
+  prefix?: PathPrefix
+}
+
+export interface PathResolverOptions {
+  /** Where the JSON report was read from, on this side of the boundary. */
+  reportPath: string
+  /** Explicit mappings. Tried before anything is worked out. */
+  prefixes?: PathPrefix[]
+  /** Existence check, injectable for tests. */
+  exists?: (filePath: string) => boolean
+}
+
+/**
+ * Parse a `FROM:TO` pair, as `--path-prefix` takes it.
+ *
+ * Split on the first colon: `TO` is a local absolute path and may itself
+ * contain one on Windows, whereas `FROM` comes from a container and will not.
+ */
+export function parsePathPrefix(value: string): PathPrefix | null {
+  const separator = value.indexOf(':')
+  if (separator <= 0) return null
+
+  const from = value.slice(0, separator).trim()
+  const to = value.slice(separator + 1).trim()
+  if (!from || !to) return null
+
+  return { from, to }
+}
+
+/**
+ * Build the function that turns a recorded path into a readable one.
+ *
+ * A path that already resolves is left alone, so this costs one `stat` per
+ * attachment when the report and the files are on the same side. A mapping
+ * worked out for one attachment is kept and tried first for the rest, so the
+ * search runs once per run rather than once per image.
+ */
+export function createPathResolver(
+  options: PathResolverOptions,
+): (filePath: string) => PathResolution {
+  const exists = options.exists ?? ((filePath: string) => fs.existsSync(filePath))
+  const explicit = options.prefixes ?? []
+  const searchRoots = ancestors(path.dirname(path.resolve(options.reportPath)))
+  const learned: PathPrefix[] = []
+
+  /** Hang tails of the recorded path off each directory around the report. */
+  function search(filePath: string): PathResolution | null {
+    const target = splitPath(filePath)
+
+    // Longest tail first, so the most specific match wins. Stop one short of
+    // the whole path: something has to be left to rewrite.
+    for (let length = target.components.length - 1; length >= MIN_TAIL_COMPONENTS; length--) {
+      const tail = target.components.slice(target.components.length - length).join('/')
+
+      for (const root of searchRoots) {
+        const candidate = `${root.replace(/[\\/]+$/, '')}/${tail}`
+        if (!exists(candidate)) continue
+
+        return {
+          path: candidate,
+          found: true,
+          prefix: { from: joinPath(target, target.components.length - length), to: root },
+        }
+      }
+    }
+
+    return null
+  }
+
+  return (filePath: string): PathResolution => {
+    if (exists(filePath)) return { path: filePath, found: true }
+
+    for (const prefix of [...explicit, ...learned]) {
+      const rewritten = applyPrefix(filePath, prefix)
+      if (rewritten && exists(rewritten)) return { path: rewritten, found: true, prefix }
+    }
+
+    const discovered = search(filePath)
+    if (!discovered) return { path: filePath, found: false }
+
+    if (discovered.prefix) learned.push(discovered.prefix)
+    return discovered
+  }
+}
+
+/** Swap one prefix for another, or null when the path is not under it. */
+function applyPrefix(filePath: string, prefix: PathPrefix): string | null {
+  const from = splitPath(prefix.from)
+  const target = splitPath(filePath)
+
+  if (target.components.length < from.components.length) return null
+  for (let index = 0; index < from.components.length; index++) {
+    if (target.components[index] !== from.components[index]) return null
+  }
+
+  const rest = target.components.slice(from.components.length)
+  const to = prefix.to.replace(/[\\/]+$/, '')
+  return rest.length === 0 ? to : `${to}/${rest.join('/')}`
+}
+
+interface SplitPath {
+  /** `/`, `C:/`, or empty for a relative path. */
+  root: string
+  components: string[]
+}
+
+/**
+ * Split a path into a root and its components, accepting either separator.
+ *
+ * The two sides of the boundary need not agree on the separator, and the
+ * recorded paths come from a report rather than from this platform.
+ */
+function splitPath(value: string): SplitPath {
+  const match = /^([A-Za-z]:[\\/]|[\\/])?/.exec(value)
+  const prefix = match?.[1] ?? ''
+  return {
+    root: prefix.replace(/\\/g, '/'),
+    components: value.slice(prefix.length).split(/[\\/]+/).filter(Boolean),
+  }
+}
+
+/** Rebuild a path from its first `count` components. */
+function joinPath(split: SplitPath, count: number): string {
+  return split.root + split.components.slice(0, count).join('/')
+}
+
+/** A directory and every directory above it. */
+function ancestors(directory: string): string[] {
+  const out: string[] = []
+  let current = directory
+
+  for (;;) {
+    out.push(current)
+    const parent = path.dirname(current)
+    if (parent === current) return out
+    current = parent
+  }
+}

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -275,6 +275,14 @@ setup() {
 }
 
 @test "visual diff: the summary says why images were not uploaded" {
+  # Say so plainly when the summary went somewhere else entirely, rather than
+  # reporting a failed grep against a file that was never written.
+  if [ ! -s "$BATS_FILE_TMPDIR/visual_diff_summary.md" ]; then
+    echo "No summary was written to \$GITHUB_STEP_SUMMARY. Log:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt" >&2
+    return 1
+  fi
+
   # No upload token here, which must read as an absent token rather than as a
   # missing file — the two used to be the same sentence.
   if ! grep -q "not uploaded (no upload token configured)" "$BATS_FILE_TMPDIR/visual_diff_summary.md"; then

--- a/test/integration.bats
+++ b/test/integration.bats
@@ -202,6 +202,108 @@ setup() {
   fi
 }
 
+@test "setup: write visual diff test" {
+  write_visual_diff_test
+}
+
+@test "visual diff: write the baseline screenshot" {
+  # The helper leaves the shell in the project directory, so look for the
+  # baseline relative to it rather than joining the path a second time.
+  run_visual_diff_baseline
+
+  if ! ls test/playwright/tests/visual-diff.spec.ts-snapshots/*.png >/dev/null 2>&1; then
+    echo "Expected a baseline screenshot to be written. Output:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_baseline_output.txt" >&2
+    return 1
+  fi
+}
+
+@test "visual diff: the comparison fails" {
+  run_visual_diff_tests
+
+  local exit_code
+  exit_code="$(cat "$BATS_FILE_TMPDIR/visual_diff_exit_code")"
+  if [ "$exit_code" -eq 0 ]; then
+    echo "Expected the visual comparison to fail, but it passed. Output:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_output.txt" >&2
+    return 1
+  fi
+}
+
+@test "visual diff: the report records a container path for the diff image" {
+  PROJECT_DIR="$(cat "$BATS_FILE_TMPDIR/project_dir")"
+  local report="$PROJECT_DIR/test/playwright/visual-diff-results.json"
+
+  if [ ! -f "$report" ]; then
+    echo "Expected a JSON report at $report." >&2
+    return 1
+  fi
+
+  # This is the boundary the failure summary has to cross: the diff image is
+  # the only attachment kind carrying a path, and that path is the container's.
+  if ! grep -q '"path": *"/var/www/html/[^"]*-diff\.png"' "$report"; then
+    echo "Expected a container-side path for the diff image in the report:" >&2
+    grep -o '"path": *"[^"]*"' "$report" >&2 || true
+    return 1
+  fi
+}
+
+@test "visual diff: the failure summary reads the container's diff image" {
+  run_visual_diff_failure_summary
+
+  local exit_code
+  exit_code="$(cat "$BATS_FILE_TMPDIR/visual_diff_summary_exit_code")"
+  if [ "$exit_code" -ne 0 ]; then
+    echo "Failure summary exited with code $exit_code. Log:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt" >&2
+    return 1
+  fi
+
+  # Ran on the host against a report written in the container, so the paths
+  # only resolve if they were re-rooted onto the checkout.
+  if ! grep -q "Remapped .* attachment path" "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt"; then
+    echo "Expected the summary to re-root the container paths. Log:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt" >&2
+    return 1
+  fi
+
+  if grep -q "could not be read" "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt"; then
+    echo "The diff image was not readable from the host. Log:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt" >&2
+    return 1
+  fi
+}
+
+@test "visual diff: the summary says why images were not uploaded" {
+  # No upload token here, which must read as an absent token rather than as a
+  # missing file — the two used to be the same sentence.
+  if ! grep -q "not uploaded (no upload token configured)" "$BATS_FILE_TMPDIR/visual_diff_summary.md"; then
+    echo "Expected the summary to name the missing token. Summary:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_summary.md" >&2
+    return 1
+  fi
+
+  if grep -q "could not be read" "$BATS_FILE_TMPDIR/visual_diff_summary.md"; then
+    echo "The summary reported an unreadable image. Summary:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_summary.md" >&2
+    return 1
+  fi
+}
+
+@test "visual diff: the comment reports the failure" {
+  if ! grep -q "visual comparison fixture" "$BATS_FILE_TMPDIR/visual_diff_comment.md"; then
+    echo "Expected the failing test in the comment body. Comment:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_comment.md" >&2
+    return 1
+  fi
+
+  if ! grep -qE '<!-- playwright-drupal-failures: [1-9]' "$BATS_FILE_TMPDIR/visual_diff_comment.md"; then
+    echo "Expected a non-zero failure marker in the comment body. Comment:" >&2
+    cat "$BATS_FILE_TMPDIR/visual_diff_comment.md" >&2
+    return 1
+  fi
+}
+
 @test "setup: write recipe test" {
   write_recipe_test
 }

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -492,6 +492,92 @@ run_a11y_baseline_tests() {
   set -e
 }
 
+# The failure summary reads the report from outside the container that wrote
+# it, so the one attachment kind carrying a file path — the snapshot comparison
+# images — is the only kind that can land on the wrong side of that boundary.
+# Accessibility screenshots are attached as a body and inlined into the report
+# as base64, so they never exercise it. Produce a real failing comparison.
+#
+# The page is built with setContent() rather than fetched from Drupal: the
+# subject here is the path the diff image is written to, and a fixture that
+# cannot vary with site content makes the failure deterministic.
+write_visual_diff_test() {
+  PROJECT_DIR="$(cat "$BATS_FILE_TMPDIR/project_dir")"
+
+  cd "$PROJECT_DIR"
+
+  cat > test/playwright/tests/visual-diff.spec.ts << 'TESTEOF'
+import { test, expect } from '@playwright/test';
+
+test('visual comparison fixture', async ({ page }) => {
+  const colour = process.env.VISUAL_DIFF_COLOUR ?? 'white';
+  await page.setContent(`<body style="margin:0;background:${colour}"><h1>Visual diff fixture</h1></body>`);
+  await expect(page).toHaveScreenshot('fixture.png', { maxDiffPixels: 0 });
+});
+TESTEOF
+}
+
+run_visual_diff_baseline() {
+  PROJECT_DIR="$(cat "$BATS_FILE_TMPDIR/project_dir")"
+
+  cd "$PROJECT_DIR"
+
+  # Keep this run away from test-results/, which holds the report the workflow
+  # picks up, and off the JSON reporter, which would overwrite it.
+  set +e
+  ddev exec -d /var/www/html/test/playwright \
+    npx playwright test tests/visual-diff.spec.ts --project=chromium --update-snapshots \
+    --reporter=line --output=test-results-visual \
+    2>&1 | tee "$BATS_FILE_TMPDIR/visual_baseline_output.txt" >&3
+  echo "${PIPESTATUS[0]}" > "$BATS_FILE_TMPDIR/visual_baseline_exit_code"
+  set -e
+}
+
+# Fail the comparison against the baseline just written, and keep the report
+# out of test-results/: that is where every other suite's report lives, and
+# Playwright empties the output directory at the start of each run.
+run_visual_diff_tests() {
+  PROJECT_DIR="$(cat "$BATS_FILE_TMPDIR/project_dir")"
+
+  cd "$PROJECT_DIR"
+
+  set +e
+  ddev exec -d /var/www/html/test/playwright \
+    bash -c 'VISUAL_DIFF_COLOUR=red PLAYWRIGHT_JSON_OUTPUT_NAME=visual-diff-results.json \
+      npx playwright test tests/visual-diff.spec.ts --project=chromium --reporter=json \
+      --output=test-results-visual' \
+    > "$BATS_FILE_TMPDIR/visual_diff_output.txt" 2>&1
+  echo "$?" > "$BATS_FILE_TMPDIR/visual_diff_exit_code"
+  set -e
+
+  # Leave the tree as it was found: a spec that fails by design would fail any
+  # later full-suite run.
+  rm -f test/playwright/tests/visual-diff.spec.ts
+  rm -rf test/playwright/tests/visual-diff.spec.ts-snapshots
+}
+
+# Run the failure summary the way a workflow does — on the host, against a
+# report whose attachment paths were written inside the container.
+run_visual_diff_failure_summary() {
+  PROJECT_DIR="$(cat "$BATS_FILE_TMPDIR/project_dir")"
+
+  cd "$PROJECT_DIR"
+
+  local command
+  command="test/playwright/node_modules/@lullabot/playwright-drupal/lib/github/failure-summary.js"
+
+  set +e
+  node "$command" \
+    --report-path=test/playwright/visual-diff-results.json \
+    --comment-path="$BATS_FILE_TMPDIR/visual_diff_comment.md" \
+    > "$BATS_FILE_TMPDIR/visual_diff_summary.md" \
+    2> "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt"
+  echo "$?" > "$BATS_FILE_TMPDIR/visual_diff_summary_exit_code"
+  set -e
+
+  cat "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt" >&3
+}
+
 write_recipe_test() {
   PROJECT_DIR="$(cat "$BATS_FILE_TMPDIR/project_dir")"
 

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -566,12 +566,19 @@ run_visual_diff_failure_summary() {
   local command
   command="test/playwright/node_modules/@lullabot/playwright-drupal/lib/github/failure-summary.js"
 
+  # Point $GITHUB_STEP_SUMMARY at a file of our own. The command writes the
+  # summary there whenever it is set, which on a runner it always is — so
+  # reading stdout instead would find it empty under CI and full locally, and
+  # this run's invented failure would land in the real job summary.
+  #
+  # That frees stdout, which is where workflow commands have to go, so both
+  # streams can be merged into one log and asserted on the same way either way.
   set +e
-  node "$command" \
-    --report-path=test/playwright/visual-diff-results.json \
-    --comment-path="$BATS_FILE_TMPDIR/visual_diff_comment.md" \
-    > "$BATS_FILE_TMPDIR/visual_diff_summary.md" \
-    2> "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt"
+  env GITHUB_STEP_SUMMARY="$BATS_FILE_TMPDIR/visual_diff_summary.md" \
+    node "$command" \
+      --report-path=test/playwright/visual-diff-results.json \
+      --comment-path="$BATS_FILE_TMPDIR/visual_diff_comment.md" \
+      > "$BATS_FILE_TMPDIR/visual_diff_summary_log.txt" 2>&1
   echo "$?" > "$BATS_FILE_TMPDIR/visual_diff_summary_exit_code"
   set -e
 


### PR DESCRIPTION
Visual diff screenshots were never uploaded when Playwright ran inside DDEV. Playwright's JSON reporter copies each attachment's path through verbatim, so a run in the web container records its diff images under /var/www/html; the failure-summary action runs with `shell: bash` on the runner, where that path does not exist. readFileSync failed, the uploader counted a skip, and the rendered output said "N screenshot(s) captured, not uploaded" — the same sentence it shows when no token is configured. Nothing failed and nothing was logged above debug level, so a working token read as a forgotten one.

Only snapshot comparison images were affected, which is why the feature looked like it worked: accessibility screenshots are attached with a body rather than a file, and the reporter inlines those as base64, so they reach uploadBuffer() and upload fine. The -diff/-actual/-expected images are the only attachments carrying a path.

Locate them instead. A bind mount means both views of a file agree on everything below the mount point, so progressively longer tails of an unreadable path are hung off the directories around the report until one names a file that is really there — longest tail first, never on a file name alone, and every candidate confirmed against the disk, so a wrong guess finds nothing rather than the wrong image. The report's own config is no use for this: rootDir is the test directory rather than the project root, and outputDir need not contain the report. --path-prefix=FROM:TO and a matching action input cover what cannot be worked out.

Say which problem it is, too. Path resolution runs whether or not uploads are switched on, so an unreachable attachment is reported even on a fork build that was never going to upload it. Unreadable attachments raise a ::warning::, and the summary and comment now distinguish "no upload token configured" from "N could not be read from the path recorded in the report" — different problems with different fixes.

test/integration.bats only ever exercised accessibility checks, and asserted they pass, so the one attachment kind carrying a path was never produced. It now fails a real toHaveScreenshot inside the container and runs the shipped command against that report from the host.


Claude-Session: https://claude.ai/code/session_01HD1zqp2iz7u5KEWKnUTsAi