### PR TITLE
fix(images): settle the image wait on error as well as load

### DIFF
--- a/src/util/images.test.ts
+++ b/src/util/images.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 
-import { decodeVisibleImages, waitForImagesToDecode } from './images'
+import { decodeVisibleImages, settleImage, waitForImagesToDecode } from './images'
 
 /**
  * A stand-in for the parts of HTMLImageElement decodeVisibleImages() touches.
@@ -179,6 +179,86 @@ describe('decodeVisibleImages', () => {
     expect(await decodeVisibleImages({ timeoutMs: 0, ...fast })).toEqual([
       'https://example.com/missing.jpg',
     ])
+  })
+})
+
+/**
+ * A stand-in for the parts of HTMLImageElement settleImage() touches.
+ *
+ * settleImage() also runs in the browser, so it is exercised against a fake
+ * element whose load and error events can be fired on demand.
+ */
+function makeSettleImage(options: { width?: number, height?: number, complete?: boolean } = {}) {
+  const listeners: Record<string, Array<() => void>> = { load: [], error: [] }
+
+  return {
+    width: options.width ?? 100,
+    height: options.height ?? 100,
+    complete: options.complete ?? false,
+    /** Assigning these instead of adding listeners would clobber the page's. */
+    onload: null,
+    onerror: null,
+    addEventListener: (type: string, handler: () => void) => {
+      listeners[type].push(handler)
+    },
+    removeEventListener: (type: string, handler: () => void) => {
+      listeners[type] = listeners[type].filter(h => h !== handler)
+    },
+    fire: (type: 'load' | 'error') => {
+      listeners[type].slice().forEach(handler => handler())
+    },
+    listenerCount: () => listeners.load.length + listeners.error.length,
+  }
+}
+
+describe('settleImage', () => {
+  it('does not wait for an image that has already settled', () => {
+    const settled = makeSettleImage({ complete: true })
+
+    // No promise back means nothing to await.
+    expect(settleImage(settled as any)).toBeUndefined()
+    expect(settled.listenerCount()).toBe(0)
+  })
+
+  it('does not wait for a 1x1 visually-hidden image', () => {
+    // Chrome never loads these at desktop widths, so waiting would hang.
+    const hidden = makeSettleImage({ width: 1, height: 1, complete: false })
+
+    expect(settleImage(hidden as any)).toBeUndefined()
+    expect(hidden.listenerCount()).toBe(0)
+  })
+
+  it('resolves once a loading image loads', async () => {
+    const loading = makeSettleImage()
+    const settled = settleImage(loading as any)
+    loading.fire('load')
+
+    await expect(settled).resolves.toBeUndefined()
+  })
+
+  it('resolves once a loading image errors', async () => {
+    // The regression: an image that 404s or 503s after the wait begins only
+    // ever fires `error`. Waiting on `load` alone hung until the test timed
+    // out, and never reached the decode retry that could have recovered it.
+    const loading = makeSettleImage()
+    const settled = settleImage(loading as any)
+    loading.fire('error')
+
+    await expect(settled).resolves.toBeUndefined()
+  })
+
+  it('cleans up both listeners once settled, and leaves the page handlers alone', async () => {
+    const loading = makeSettleImage()
+    const settled = settleImage(loading as any)
+    expect(loading.listenerCount()).toBe(2)
+
+    loading.fire('error')
+    await settled
+
+    expect(loading.listenerCount()).toBe(0)
+    // Assigning onload/onerror would have replaced whatever the page installed.
+    expect(loading.onload).toBeNull()
+    expect(loading.onerror).toBeNull()
   })
 })
 

--- a/src/util/images.ts
+++ b/src/util/images.ts
@@ -25,17 +25,7 @@ export async function waitForImages(page: Page, selector: string): Promise<void>
   }
 
   // Make sure all images have loaded.
-  // @ts-ignore
-  const promises = (await locators.all()).map(locator => locator.evaluate(image => {
-    // Make sure 1x1 images that are visually hidden for accessibility (like
-    // on the Umami home page) don't hang waiting for the image to load. Even
-    // though the images are :visible, Chrome doesn't load the image at desktop
-    // widths.
-    // See https://www.tpgi.com/the-anatomy-of-visually-hidden/ for details on
-    // how .visually-hidden works.
-    // @ts-ignore
-    return ((image.width <= 1 && image.height <= 1) || image.complete || new Promise(f => image.onload = f));
-  }));
+  const promises = (await locators.all()).map(locator => locator.evaluate(settleImage));
   await Promise.all(promises);
 
   // The wait above treats an errored image as "loaded": a 404 -- or a Stage
@@ -81,6 +71,49 @@ export async function waitForImages(page: Page, selector: string): Promise<void>
     }
     return window.scrollY == 0;
   }, forcedScroll);
+}
+
+/**
+ * Wait for a single image to stop being in flight.
+ *
+ * Returns without a promise for an image that needs no waiting at all: one that
+ * has already settled, or a 1x1 image that is visually hidden for accessibility
+ * (like on the Umami home page), which would otherwise hang forever -- even
+ * though such images are :visible, Chrome doesn't load them at desktop widths. See
+ * https://www.tpgi.com/the-anatomy-of-visually-hidden/ for how .visually-hidden
+ * works.
+ *
+ * Otherwise it waits for the request to finish, whether it succeeds or fails.
+ * Waiting on `load` alone would hang until the test timed out on any image that
+ * errors after the wait begins -- a 404, or a Stage File Proxy URL that 503s
+ * while it fetches the original on demand -- because such an image only ever
+ * fires `error`. That hang is worse than useless here: it happens before
+ * waitForImagesToDecode() runs, so it also denies the one piece of code that
+ * knows how to re-request a broken image the chance to recover it. Settling on
+ * `error` hands the image on to that recovery instead.
+ *
+ * Listeners are added rather than assigned to `onload`/`onerror` so that any
+ * handler the page itself installed keeps working.
+ *
+ * This runs in the browser via `evaluate()`, which serializes the function
+ * source, so it must stay self-contained and reference nothing else in this
+ * module. It is exported so the waiting can be tested directly.
+ *
+ * @param image
+ */
+export function settleImage(image: HTMLImageElement): void | Promise<void> {
+  if ((image.width <= 1 && image.height <= 1) || image.complete) {
+    return;
+  }
+  return new Promise<void>(resolve => {
+    const settled = () => {
+      image.removeEventListener("load", settled);
+      image.removeEventListener("error", settled);
+      resolve();
+    };
+    image.addEventListener("load", settled);
+    image.addEventListener("error", settled);
+  });
 }
 
 /**


### PR DESCRIPTION
waitForImages() waited on `new Promise(f => image.onload = f)` for any image that was still in flight. An image that fails after that wait begins -- a 404, or a Stage File Proxy URL that 503s while it fetches the original on demand -- only ever fires `error`, so the promise never settled and the wait burned the whole test timeout.

The hang also landed in the worst possible place: it happens before waitForImagesToDecode(), so it denied the one piece of code that knows how to re-request a broken image any chance to recover it. A page whose image 503s once and succeeds on retry hung for the full timeout instead of recovering in under two seconds.

This is why regenerating a single screenshot baseline could flake while a full run was fine: in a full run the image is already cached from an earlier test and is `complete` before the wait starts, taking the short-circuit and never registering the listener.

Listen for both `load` and `error`, and add listeners rather than assigning `onload` so any handler the page installed keeps working. The predicate moves to an exported settleImage() so it can be unit tested, matching how decodeVisibleImages() is already structured.


Claude-Session: https://claude.ai/code/session_01BSvvxJ2khJuCCpqpTmFFgR