### PR TITLE
feat: add an opt-in machine-wide mutex for Playwright runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,21 @@ jobs:
           path: lullabot-playwright-drupal-*.tgz
           retention-days: 1
 
+  shell-test:
+    # bin/playwright-mutex needs neither DDEV nor Docker, so it does not belong
+    # behind the fifteen-minute integration matrix below.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: Run shell tests
+        run: bats test/mutex.bats
+
   test:
     needs: build
     runs-on: ubuntu-24.04

--- a/bin/playwright-mutex
+++ b/bin/playwright-mutex
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+
+# Machine-wide mutex for Playwright runs. Opt-in: does nothing unless
+# PLAYWRIGHT_MUTEX is set to 1.
+#
+# definePlaywrightDrupalConfig() asks for `cpus - 2` workers, so a single suite
+# already claims nearly the whole machine. Two suites at once do not each take
+# half the time; they take longer than running them back to back, and starve
+# each other badly enough to fail visual comparisons that have nothing wrong
+# with them. Nothing in Playwright or DDEV notices this, because each worktree
+# or checkout is its own DDEV project and they never see each other.
+#
+# The lock file lives on `ddev-global-cache`, the Docker named volume DDEV
+# mounts into every project's web container at /mnt/ddev-global-cache. That is
+# one inode on the host, so flock(2) is honoured across containers - which is
+# what makes this work across projects with no per-project setup and no
+# `ddev restart`. The kernel releases the lock however the holder dies, so
+# there is no stale lock to clear.
+#
+# Usage:
+#   playwright-mutex <command> [args...]
+#
+# Environment:
+#   PLAYWRIGHT_MUTEX=1          enable the lock. Unset or 0 runs the command
+#                               unchanged, which is the default.
+#   PLAYWRIGHT_MUTEX=force      enable the lock even when CI is set. See below.
+#   PLAYWRIGHT_MUTEX_WAIT=<s>   seconds to wait for the lock (default 1800).
+#                               0 means do not wait at all.
+#   PLAYWRIGHT_MUTEX_FAIL_FAST=1
+#                               refuse immediately instead of waiting, for
+#                               callers that would rather do something else
+#                               than sit in a queue. Same as WAIT=0.
+#   PLAYWRIGHT_MUTEX_DIR=<dir>  lock location (default
+#                               /mnt/ddev-global-cache/playwright).
+#   PLAYWRIGHT_MUTEX_HELD=1     set for the command being run, so nested
+#                               invocations pass through instead of blocking
+#                               on a lock their own process tree holds.
+#
+# The lock is skipped when CI is set. CI jobs get their own machine, and
+# sharded runs (`task playwright:run shard=1/3`) are supposed to overlap;
+# worse, several jobs on one self-hosted runner share a Docker daemon and so
+# would share this volume, turning a correct parallel build into a queue or a
+# pile of failures. PLAYWRIGHT_MUTEX=force overrides this for the rare CI
+# machine that really does need serialising.
+#
+# Exits 75 (EX_TEMPFAIL) when the lock could not be acquired, which is distinct
+# from any status Playwright itself produces, so "busy" is never mistaken for
+# "tests failed". Nothing has run at that point.
+
+set -uo pipefail
+
+lock_dir="${PLAYWRIGHT_MUTEX_DIR:-/mnt/ddev-global-cache/playwright}"
+lock_file="$lock_dir/mutex.lock"
+holder_file="$lock_dir/mutex.holder"
+enabled="${PLAYWRIGHT_MUTEX:-0}"
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: ${0##*/} <command> [args...]" >&2
+  exit 64
+fi
+
+# Off by default. Wiring this into a Taskfile is therefore inert until someone
+# opts in, and every wrapped task keeps behaving exactly as it did before.
+case "$enabled" in
+  1 | force) ;;
+  *) exec "$@" ;;
+esac
+
+# Reentrancy. flock(2) is held by the open file description, not by the process
+# tree, so a nested acquisition would block against a lock this very tree
+# already holds and then time out.
+if [ "${PLAYWRIGHT_MUTEX_HELD:-}" = "1" ]; then
+  exec "$@"
+fi
+
+if [ -n "${CI:-}" ] && [ "$enabled" != "force" ]; then
+  exec "$@"
+fi
+
+# No shared volume means nothing to contend with - a plain container, a host
+# shell, a non-DDEV environment. Run rather than fail, but say so: the
+# alternative to a warning here is a machine that quietly stopped serialising.
+if [ ! -d "${lock_dir%/*}" ]; then
+  echo "playwright-mutex: ${lock_dir%/*} is not mounted; running WITHOUT the mutex." >&2
+  exec "$@"
+fi
+
+mkdir -p "$lock_dir" 2>/dev/null
+: >>"$lock_file" 2>/dev/null
+
+if [ ! -r "$lock_file" ]; then
+  echo "playwright-mutex: cannot open $lock_file; running WITHOUT the mutex." >&2
+  exec "$@"
+fi
+
+# Read-only fd on purpose: flock(2) only needs an open file description, and
+# asking for write access would fail against a lock file another user created.
+exec 9<"$lock_file"
+
+# Parsed, never sourced. The file holds a `command=` line with spaces in it,
+# and sourcing that would run its tail.
+holder_field() {
+  [ -r "$holder_file" ] || return 0
+  sed -n "s/^$1=//p" "$holder_file" 2>/dev/null | head -n 1
+}
+
+# Best-effort breadcrumb for whoever is waiting. The lock, not this file, is
+# authoritative; it exists only to make the message useful.
+describe_holder() {
+  local project started started_human elapsed=""
+  project="$(holder_field project)"
+  started="$(holder_field started)"
+  started_human="$(holder_field started_human)"
+
+  case "$started" in
+    "" | *[!0-9]*) ;;
+    *) elapsed=" for $(( ( $(date +%s) - started ) / 60 ))m" ;;
+  esac
+
+  if [ -n "$project" ]; then
+    echo "held by project '${project}'${elapsed} (started ${started_human:-unknown})"
+  else
+    echo "held${elapsed} by an unknown run"
+  fi
+}
+
+wait_seconds="${PLAYWRIGHT_MUTEX_WAIT:-1800}"
+case "$wait_seconds" in
+  "" | *[!0-9]*)
+    echo "playwright-mutex: ignoring non-numeric PLAYWRIGHT_MUTEX_WAIT='${wait_seconds}'." >&2
+    wait_seconds=1800
+    ;;
+esac
+if [ "${PLAYWRIGHT_MUTEX_FAIL_FAST:-}" = "1" ]; then
+  wait_seconds=0
+fi
+
+# Try once without blocking so the common case stays silent, and so there is
+# something to print before a wait that could last half an hour.
+if ! flock -n 9; then
+  if [ "$wait_seconds" -gt 0 ]; then
+    echo "playwright-mutex: another Playwright run is $(describe_holder)." >&2
+    echo "playwright-mutex: waiting up to ${wait_seconds}s for it to finish." >&2
+  fi
+
+  if ! flock -w "$wait_seconds" 9; then
+    {
+      echo ""
+      echo "playwright-mutex: another Playwright run is $(describe_holder)."
+      echo ""
+      echo "Nothing was run. Playwright uses cpus-2 workers, so a second suite would"
+      echo "make both runs slower than running them one after the other, and can fail"
+      echo "visual comparisons through CPU starvation."
+      echo ""
+      echo "Wait for the current run to finish and re-run this command. Set"
+      echo "PLAYWRIGHT_MUTEX_WAIT to a larger number of seconds to queue instead,"
+      echo "or PLAYWRIGHT_MUTEX=0 to opt out entirely."
+      echo ""
+    } >&2
+    exit 75
+  fi
+fi
+
+{
+  echo "project=${DDEV_SITENAME:-unknown}"
+  echo "pid=$$"
+  echo "started=$(date +%s)"
+  echo "started_human=$(date '+%Y-%m-%d %H:%M:%S')"
+  echo "command=$*"
+} >"$holder_file" 2>/dev/null
+trap 'rm -f "$holder_file" 2>/dev/null' EXIT
+
+PLAYWRIGHT_MUTEX_HELD=1 "$@"
+exit $?

--- a/docs/getting-started/playwright-configuration.md
+++ b/docs/getting-started/playwright-configuration.md
@@ -6,11 +6,16 @@ The `definePlaywrightDrupalConfig()` function returns a complete Playwright conf
 |---|---|
 | `use.baseURL` | `process.env.DDEV_PRIMARY_URL` |
 | `fullyParallel` | `true` |
-| `workers` | `Math.max(2, os.cpus().length - 2)` |
+| `workers` | `Math.max(2, os.cpus().length - 2)`, or `PLAYWRIGHT_WORKERS` when set |
 | `reporter` | CI: `[['line'], ['html'], ['json', ...]]`; Local: `[['html', ...], ['list'], ['json', ...]]` |
 | `globalSetup` | Auto-resolved path to this package's `global-setup` module |
 
 ## Overriding Defaults
+
+`PLAYWRIGHT_WORKERS` overrides `workers` for a single invocation, taking
+precedence over anything passed here — see
+[Running Tests Concurrently](../working-with-tests/running-tests-concurrently.md).
+Everything else is set by the overrides argument.
 
 Plain-object properties are deep-merged with their defaults at every nesting level. For example, providing `use.ignoreHTTPSErrors` keeps the default `use.baseURL` while adding your setting. Non-object properties (including arrays like `reporter`) replace the default entirely.
 

--- a/docs/working-with-tests/running-tests-concurrently.md
+++ b/docs/working-with-tests/running-tests-concurrently.md
@@ -1,0 +1,252 @@
+# Running Tests Concurrently
+
+`definePlaywrightDrupalConfig()` asks for `cpus - 2` workers, so a single suite
+already claims nearly the whole machine. That is the right default for the
+common case — one developer, one checkout, one run at a time — and it is the
+wrong default the moment two runs overlap.
+
+Overlap is easy to arrange without noticing. Each git worktree is normally its
+own DDEV project, CI-style scripts get run by hand, and coding agents will
+happily start a suite in one worktree while another is still going. Neither run
+can see the other, so both keep asking for `cpus - 2` workers on a machine that
+has one set of CPUs. Two suites at once do not each take half the time; they
+take longer than running them back to back, and they starve each other badly
+enough to fail visual comparisons that have nothing wrong with them.
+
+There are two ways to deal with this, and they solve different problems.
+
+## Dialing Down a Single Run
+
+`PLAYWRIGHT_WORKERS` overrides the worker count for one invocation:
+
+```console
+PLAYWRIGHT_WORKERS=4 ddev task playwright:run
+```
+
+It accepts a positive integer or a percentage, matching Playwright's own
+`workers` option:
+
+```console
+PLAYWRIGHT_WORKERS=50% ddev task playwright:run
+```
+
+This is the tool for "I know something else is using this machine right now."
+It deliberately takes precedence over a `workers` value passed to
+`definePlaywrightDrupalConfig()`, because the point is to adjust a run without
+editing a config file that is shared and committed. Playwright's own
+`--workers` flag still wins over both.
+
+An unusable value — `PLAYWRIGHT_WORKERS=lots`, `PLAYWRIGHT_WORKERS=0` — raises
+an error rather than falling back to the default. Silently running a whole
+suite at the wrong parallelism is worse than refusing to start.
+
+## Serialising Runs Across the Machine
+
+`PLAYWRIGHT_WORKERS` still relies on somebody knowing to set it. The mutex
+removes that requirement: with it enabled, one Playwright run happens at a time
+across every DDEV project on the machine, and the second one is told so.
+
+It is **off by default**. Turn it on by setting `PLAYWRIGHT_MUTEX=1` in the web
+container's environment — most easily in `.ddev/config.yaml`:
+
+```yaml
+web_environment:
+  - PLAYWRIGHT_MUTEX=1
+```
+
+or `.ddev/config.local.yaml` if you would rather it stay out of git. Run
+`ddev restart` afterwards.
+
+`playwright:run`, `playwright:visualdiff` and `playwright:regenerate` then take
+the lock for the whole of their work, `playwright:install` included — rebuilding
+the test site is itself expensive enough to be worth serialising.
+
+### What Happens When the Lock Is Taken
+
+The default is to queue, waiting up to 30 minutes:
+
+```console
+$ ddev task playwright:visualdiff
+playwright-mutex: another Playwright run is held by project 'my-site-review' for 6m (started 2026-08-20 09:12:44).
+playwright-mutex: waiting up to 1800s for it to finish.
+```
+
+Set `PLAYWRIGHT_MUTEX_WAIT` to change that number of seconds, or
+`PLAYWRIGHT_MUTEX_FAIL_FAST=1` to be refused immediately instead. Refusing is
+the better choice when the caller has something else it could be doing —
+notably a coding agent, which would otherwise sit in a queue for half an hour.
+
+A refusal exits **75** (`EX_TEMPFAIL`), which no Playwright exit status uses, so
+"busy" is never mistaken for "tests failed". Nothing has run at that point:
+wait for the other suite and issue the same command again.
+
+!!! note "Exit codes through `task`"
+
+    Task reports a failing task as exit status **201** regardless of what the
+    command returned. To see the 75 — or Playwright's own exit code — pass
+    `-x`: `ddev task -x playwright:run`. The message on stderr identifies a
+    mutex refusal either way.
+
+### Where the Lock Lives
+
+The lock file is on `ddev-global-cache`, the Docker named volume DDEV mounts
+into every project's web container at `/mnt/ddev-global-cache`. That is one
+inode on the host, so `flock(2)` is honoured across containers. Nothing needs
+adding to `docker-compose`, and no project needs restarting for another
+project's lock to apply to it.
+
+The kernel releases the lock however the holder dies — cleanly, killed, or with
+the container stopped underneath it — so there is never a stale lock to clear
+by hand.
+
+If the volume is not mounted, the mutex prints a warning and runs anyway. There
+is nothing to contend with outside DDEV, and a lock that cannot be taken must
+not stop anyone running their tests.
+
+### CI
+
+The mutex is skipped whenever `CI` is set, even with `PLAYWRIGHT_MUTEX=1`.
+Hosted runners get a machine each, sharded runs (`playwright:run shard=1/3`)
+are *supposed* to overlap, and several jobs on one self-hosted runner share a
+Docker daemon — and therefore this volume — so a lock there would turn a
+correct parallel build into a queue or a pile of failures.
+
+`PLAYWRIGHT_MUTEX=force` overrides this for the rare CI machine that really
+does need serialising.
+
+### Reference
+
+| Variable | Default | Effect |
+|---|---|---|
+| `PLAYWRIGHT_MUTEX` | unset | `1` enables the lock; `force` enables it on CI too; anything else runs unchanged |
+| `PLAYWRIGHT_MUTEX_WAIT` | `1800` | Seconds to wait for the lock before giving up |
+| `PLAYWRIGHT_MUTEX_FAIL_FAST` | unset | `1` refuses immediately instead of waiting |
+| `PLAYWRIGHT_MUTEX_DIR` | `/mnt/ddev-global-cache/playwright` | Where the lock file lives |
+
+### Wrapping Your Own Commands
+
+The mutex is a plain wrapper, published as the `playwright-drupal-mutex` bin,
+so anything else competing for the same CPUs can take the same lock. `npx`
+resolves it from `test/playwright/node_modules/.bin`:
+
+```yaml
+  fixtures:refresh:
+    dir: test/playwright
+    cmds:
+      # A long database import that then warms the site should queue rather
+      # than be thrown away half an hour in, so give it a long wait.
+      - PLAYWRIGHT_MUTEX_WAIT=3600 npx playwright-drupal-mutex npx playwright test --ignore-snapshots
+```
+
+Nested invocations pass straight through: the wrapper exports
+`PLAYWRIGHT_MUTEX_HELD=1` for the command it runs, so a locked task that calls
+another locked task does not block against a lock its own process tree holds.
+
+## Refusing a Run Before It Starts
+
+The mutex is checked when a task starts, which for `playwright:run` is after
+`playwright:install` has rebuilt the test site. A coding agent can therefore
+spend several minutes on a run it was never going to be allowed to finish.
+
+Claude Code can be told to refuse those commands up front with a `PreToolUse`
+hook. This is a per-project thing rather than something the package ships, both
+because it depends on your task names and because a hook that can stop a
+developer running tests should be something you opted into deliberately. Adapt
+and save as `.claude/hooks/playwright-mutex-gate.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Refuse to start a Playwright run while another one holds the mutex.
+#
+# Everything here fails open. A hook that cannot reach Docker must not be able
+# to stop someone running their tests; the worst case is the mutex itself
+# refusing the run a few minutes later, which is what would have happened
+# without the hook at all.
+set -uo pipefail
+
+input=$(cat)
+
+command -v jq >/dev/null 2>&1 || exit 0
+command -v docker >/dev/null 2>&1 || exit 0
+
+[ "$(jq -r '.tool_name // empty' <<<"$input" 2>/dev/null)" = "Bash" ] || exit 0
+cmd=$(jq -r '.tool_input.command // empty' <<<"$input" 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# An escape hatch, and the commands worth gating. Anything else -- reading a
+# report, listing snapshots, editing a spec -- is untouched.
+case "$cmd" in
+  *"#no-playwright-mutex"*) exit 0 ;;
+  *"playwright test"* | *playwright:run* | *playwright:visualdiff* | \
+  *playwright:regenerate* | *playwright:install*) ;;
+  *) exit 0 ;;
+esac
+
+# The volume's host path under /var/lib/docker is root-only, so probe through
+# any running DDEV web container -- they all mount the same volume.
+container=$(docker ps --filter 'label=com.ddev.site-name' --filter 'status=running' \
+  --format '{{.Names}}' 2>/dev/null | grep -E -- '-web$' | head -n 1)
+[ -n "$container" ] || exit 0
+
+# Exit 3 means held. `flock -n` releases immediately when it succeeds, so
+# probing never blocks a real run.
+holder=$(timeout 15 docker exec "$container" sh -c '
+  dir=/mnt/ddev-global-cache/playwright
+  [ -e "$dir/mutex.lock" ] || exit 0
+  flock -n "$dir/mutex.lock" true && exit 0
+  cat "$dir/mutex.holder" 2>/dev/null
+  exit 3
+' 2>/dev/null)
+[ "$?" -eq 3 ] || exit 0
+
+project=$(sed -n 's/^project=//p' <<<"$holder" | head -n 1)
+
+reason="A Playwright run is already in progress on this machine${project:+ (project $project)}.
+
+Playwright runs with cpus-2 workers, so it already uses nearly the whole
+machine. A second suite would make both runs slower than running them one
+after the other, and CPU starvation shows up as visual comparison failures
+that look like real regressions.
+
+Do not run it now, and do not poll in a tight loop. Get on with other work and
+try again in a few minutes; a full suite takes anywhere from 5 to 30 minutes."
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'
+exit 0
+```
+
+Register it in `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/playwright-mutex-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Two things to know about it. Claude Code reads `.claude/settings.json` at
+startup, so the hook only applies to sessions started after it is on disk — a
+session that was already running when you added it will still reach the mutex
+instead, which is the designed fallback rather than a failure. And `ddev
+playwright test`, from the
+[ddev-playwright](https://github.com/lullabot/ddev-playwright) add-on, does not
+take the lock: the hook will refuse it while somebody else is running, but a
+run started that way holds nothing, and other runs will start on top of it.
+Prefer `ddev task playwright:run`.

--- a/docs/working-with-tests/visual-comparisons.md
+++ b/docs/working-with-tests/visual-comparisons.md
@@ -316,6 +316,35 @@ Selectors that don't match any element on the page are silently ignored — no e
 
 **Note:** When using a custom test function via `config.describe(myTestFunction)`, automatic mask merging is bypassed. Your custom function is responsible for applying masks itself.
 
+## Running and Regenerating Snapshots
+
+Two tasks cover the day-to-day work, and both run only the tests that have a
+`-snapshots` directory next to them:
+
+```console
+ddev task playwright:visualdiff
+ddev task playwright:regenerate
+```
+
+`playwright:regenerate` deletes every existing snapshot before rerunning with
+`--update-snapshots`, so that a test whose snapshot filenames changed does not
+leave the old files behind. Pass `delete=0` to keep them.
+
+Arguments after `--` are forwarded to `playwright test`:
+
+```console
+ddev task playwright:visualdiff -- --project chromium
+ddev task playwright:regenerate delete=0 -- --grep 'Front.page'
+```
+
+A filtered regeneration requires an explicit `delete`, because deleting every
+snapshot and then regenerating only the ones that matched would leave the rest
+missing — a regeneration that looks like it worked until the next full run.
+
+Note that these arguments are forwarded as a single string and re-split on
+spaces, so a pattern containing a space needs to avoid one: prefer
+`--grep 'Front.page'` over `--grep 'Front page'`.
+
 ## Snapshot Storage
 
 Commiting screenshots to your project repository is the easiest way to save and compare them. However, projects with many snapshots or design changes may lead to significant churn on the snapshots, which can cause [git repository size to grow significantly](https://www.lullabot.com/articles/how-calculate-git-repository-growth-over-time). Instead of committing snapshots directly to your project, consider:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - Visual Comparisons (Diffs): working-with-tests/visual-comparisons.md
     - Accessibility Tests: working-with-tests/accessibility-tests.md
     - Debugging Tests: working-with-tests/debugging-tests.md
+    - Running Tests Concurrently: working-with-tests/running-tests-concurrently.md
     - Screenshots in CI: working-with-tests/screenshots-in-ci.md
     - Drupal Testing Utilities: working-with-tests/drupal-testing-utilities.md
   - Contributing:

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       },
       "bin": {
         "playwright-drupal-a11y-summary": "bin/github-a11y-summary",
-        "playwright-drupal-failure-summary": "bin/github-failure-summary"
+        "playwright-drupal-failure-summary": "bin/github-failure-summary",
+        "playwright-drupal-mutex": "bin/playwright-mutex"
       },
       "devDependencies": {
         "@commitlint/cli": "^21.0.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "types": "lib/index.d.ts",
   "bin": {
     "playwright-drupal-a11y-summary": "./bin/github-a11y-summary",
+    "playwright-drupal-mutex": "./bin/playwright-mutex",
     "playwright-drupal-failure-summary": "./bin/github-failure-summary"
   },
   "exports": {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -15,6 +15,7 @@ describe('definePlaywrightDrupalConfig', () => {
     // Clear CI and DDEV_PRIMARY_URL before each test.
     delete process.env.CI
     delete process.env.DDEV_PRIMARY_URL
+    delete process.env.PLAYWRIGHT_WORKERS
   })
 
   afterEach(() => {
@@ -84,6 +85,40 @@ describe('definePlaywrightDrupalConfig', () => {
   it('allows overriding workers', async () => {
     const config = await loadConfig({ workers: 1 })
     expect(config.workers).toBe(1)
+  })
+
+  it('reads workers from PLAYWRIGHT_WORKERS', async () => {
+    process.env.PLAYWRIGHT_WORKERS = '3'
+    const config = await loadConfig()
+    expect(config.workers).toBe(3)
+  })
+
+  it('accepts a percentage in PLAYWRIGHT_WORKERS', async () => {
+    process.env.PLAYWRIGHT_WORKERS = '50%'
+    const config = await loadConfig()
+    expect(config.workers).toBe('50%')
+  })
+
+  it('lets PLAYWRIGHT_WORKERS win over a config override', async () => {
+    process.env.PLAYWRIGHT_WORKERS = '3'
+    const config = await loadConfig({ workers: 8 })
+    expect(config.workers).toBe(3)
+  })
+
+  it('ignores an empty PLAYWRIGHT_WORKERS', async () => {
+    process.env.PLAYWRIGHT_WORKERS = '   '
+    const config = await loadConfig()
+    expect(config.workers).toBe(Math.max(2, os.cpus().length - 2))
+  })
+
+  it('throws on an unusable PLAYWRIGHT_WORKERS', async () => {
+    process.env.PLAYWRIGHT_WORKERS = 'lots'
+    await expect(loadConfig()).rejects.toThrow(/PLAYWRIGHT_WORKERS/)
+  })
+
+  it('throws on a non-positive PLAYWRIGHT_WORKERS', async () => {
+    process.env.PLAYWRIGHT_WORKERS = '0'
+    await expect(loadConfig()).rejects.toThrow(/PLAYWRIGHT_WORKERS/)
   })
 
   it('allows overriding globalSetup', async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,8 @@ if (__dirname.includes(path.sep + 'packages' + path.sep + 'playwright-drupal')) 
  * Provides:
  * - `use.baseURL` from the `DDEV_PRIMARY_URL` environment variable
  * - `fullyParallel: true`
- * - `workers` based on CPU count (`Math.max(2, cpus - 2)`)
+ * - `workers` based on CPU count (`Math.max(2, cpus - 2)`), or the value of
+ *   the `PLAYWRIGHT_WORKERS` environment variable when it is set
  * - CI-aware `reporter` (line + html on CI; html + list locally)
  * - `globalSetup` pointing to this package's global-setup module
  *
@@ -40,6 +41,12 @@ if (__dirname.includes(path.sep + 'packages' + path.sep + 'playwright-drupal')) 
  *   level, so providing `use.baseURL` replaces the default while keeping
  *   other `use` defaults. Non-object properties (including arrays like
  *   `reporter`) replace the default entirely.
+ *
+ *   `PLAYWRIGHT_WORKERS` takes precedence over `overrides.workers`. The point
+ *   of the variable is to dial a run down without editing a config file that
+ *   is shared and committed - most often because something else is already
+ *   using the machine - so a project setting must not silently win over it.
+ *   Playwright's own `--workers` flag still overrides both.
  */
 export function definePlaywrightDrupalConfig(overrides: PlaywrightTestConfig = {}): PlaywrightTestConfig {
   const isCI = !!process.env.CI;
@@ -56,7 +63,42 @@ export function definePlaywrightDrupalConfig(overrides: PlaywrightTestConfig = {
     },
   };
 
-  return defineConfig(deepMerge(defaults, overrides));
+  const merged = deepMerge(defaults, overrides);
+
+  const workers = workersFromEnvironment();
+  if (workers !== undefined) {
+    merged.workers = workers;
+  }
+
+  return defineConfig(merged);
+}
+
+/**
+ * Read `PLAYWRIGHT_WORKERS`, returning `undefined` when it is not usable.
+ *
+ * Accepts the same shapes Playwright's `workers` option does: a positive
+ * integer, or a percentage of the available CPUs such as `50%`. Anything else
+ * is a typo rather than an instruction, and silently running the whole suite
+ * with the wrong parallelism is worse than saying so.
+ */
+function workersFromEnvironment(): number | string | undefined {
+  const raw = process.env.PLAYWRIGHT_WORKERS?.trim();
+  if (!raw) {
+    return undefined;
+  }
+
+  if (/^\d+(\.\d+)?%$/.test(raw)) {
+    return raw;
+  }
+
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+
+  throw new Error(
+    `PLAYWRIGHT_WORKERS must be a positive integer or a percentage such as '50%', got '${raw}'.`
+  );
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/tasks/playwright.yml
+++ b/tasks/playwright.yml
@@ -3,17 +3,57 @@ version: '3'
 vars:
   DOCROOT:
     sh: node -e "try { const c = require('./composer.json'); const w = (c.extra?.['drupal-scaffold']?.locations?.['web-root'] || 'web').replace(/\/$/, ''); process.stdout.write(w); } catch(e) { process.stdout.write('web'); }"
+
+  # Wrapper that serialises Playwright runs across every DDEV project on the
+  # machine. It is a no-op unless PLAYWRIGHT_MUTEX=1 is set, so wiring it in
+  # here changes nothing by default. See bin/playwright-mutex and the
+  # "Running Tests Concurrently" documentation.
+  #
+  # Falls back to `env`, which runs its arguments unchanged, so a project that
+  # vendors this Taskfile somewhere unexpected still runs its tests.
+  MUTEX:
+    sh: |
+      for candidate in \
+        "{{ .TASKFILE_DIR }}/../bin/playwright-mutex" \
+        "test/playwright/node_modules/@lullabot/playwright-drupal/bin/playwright-mutex" \
+        "node_modules/@lullabot/playwright-drupal/bin/playwright-mutex"; do
+        if [ -x "$candidate" ]; then
+          printf '%s' "$candidate"
+          exit 0
+        fi
+      done
+      printf 'env'
 tasks:
   run:
     desc: "Runs playwright functional tests."
     summary: |
       Runs Playwright tests.
         - shard=x/y: Run a fraction of tests. Optional.
+
+      Arguments after `--` are forwarded to `playwright test`:
+
+        task playwright:run -- --grep @smoke
+
+      Note that they are forwarded as a single string and re-split on spaces,
+      so a pattern containing a space needs to avoid one: prefer
+      `--grep 'Front.page'` over `--grep 'Front page'`.
+
+      With PLAYWRIGHT_MUTEX=1 set, only one run happens at a time across the
+      whole machine. See "Running Tests Concurrently" in the documentation.
+    cmds:
+      # The body is a separate task because the lock has to span both
+      # playwright:install and the run itself, and a Taskfile cmd is one shell.
+      - '{{ .MUTEX }} task -x playwright:run:locked shard={{ default "1/1" .shard }} -- {{ .CLI_ARGS }}'
+
+  # Deliberately has no desc: it is an implementation detail of playwright:run
+  # and stays out of `task --list`. It cannot be marked `internal`, because the
+  # mutex shells back out to `task` and that counts as a CLI invocation.
+  run:locked:
     cmds:
       - task: install
       - |
         cd test/playwright
-        npx playwright test --shard={{ default "1/1" .shard }}
+        npx playwright test --shard={{ default "1/1" .shard }} {{ .CLI_ARGS }}
         STATUS=$?
         echo "System uptime and load average statistics:"; uptime
         echo "If the load average is significantly different than **$(cat /proc/cpuinfo | grep processor | wc -l)** there may be too many or two few Playwright workers assigned. You might want to tweak the number of workers or shards."
@@ -156,17 +196,44 @@ tasks:
 
   visualdiff:
     desc: Runs only visual diff tests
-    deps:
-      - install
+    summary: |
+      Runs only the tests that have a -snapshots directory next to them.
+
+      Arguments after `--` are forwarded to `playwright test`:
+
+        task playwright:visualdiff -- --project chromium
+
+      They are forwarded as a single string and re-split on spaces, so a
+      pattern containing a space needs to avoid one: prefer
+      `--grep 'Front.page'` over `--grep 'Front page'`.
+
+      With PLAYWRIGHT_MUTEX=1 set, only one run happens at a time across the
+      whole machine. See "Running Tests Concurrently" in the documentation.
     cmds:
+      # See the note on playwright:run for why the body is a separate task.
+      - '{{ .MUTEX }} task -x playwright:visualdiff:locked -- {{ .CLI_ARGS }}'
+
+  visualdiff:locked:
+    cmds:
+      - task: install
       - |
         cd test/playwright
 
         # First capture all tests that have snapshots.
         TESTS=$(find . -name '*-snapshots' -type d | sed 's/-snapshots//' | sed 's/\.\///')
 
+        # Bail rather than run everything. `xargs` with an empty list still
+        # executes the command, and `playwright test` with no file filter runs
+        # the entire suite -- a green result that tested far more than asked.
+        if [ -z "$TESTS" ]; then
+          echo "No *-snapshots directories found under test/playwright." >&2
+          echo "Nothing was run. Run the test once so Playwright writes its first" >&2
+          echo "snapshot, which is what creates the directory this looks for." >&2
+          exit 1
+        fi
+
         # Run just tests with snapshots.
-        echo $TESTS | xargs npx playwright test
+        echo $TESTS | xargs npx playwright test {{ .CLI_ARGS }}
 
   regenerate:
     desc: Regenerates all Playwright snapshots, deleting existing ones by default
@@ -175,29 +242,72 @@ tasks:
       Playwright test. Then, it reruns tests with the --update-snapshots
       argument.
         - delete=<0,1>: Set to 0 to not delete existing snapshots. Useful
-                        when snapshot filenames should not change. Optional.
+                        when snapshot filenames should not change. Optional,
+                        and defaults to 1 only when no filter is given.
+
+      Arguments after `--` are forwarded to `playwright test`, and require an
+      explicit `delete` because deleting every snapshot before regenerating a
+      filtered subset would leave the rest missing.
+
+      They are forwarded as a single string and re-split on spaces, so a
+      pattern containing a space needs to avoid one: prefer
+      `--grep 'Front.page'` over `--grep 'Front page'`.
+
+      With PLAYWRIGHT_MUTEX=1 set, only one run happens at a time across the
+      whole machine. See "Running Tests Concurrently" in the documentation.
 
       Examples:
         Do not delete snapshots when regenerating.
         - task playwright:regenerate delete=0
-    deps:
-      - playwright:install
-    vars:
-      delete: '{{ default "1" .delete }}'
+
+        Regenerate only one test's snapshots, keeping the rest.
+        - task playwright:regenerate delete=0 -- --grep 'Front.page'
     cmds:
+      # See the note on playwright:run for why the body is a separate task.
+      # Both `delete` and the trailing arguments have to cross the nested task
+      # call: a nested `task` process starts with an empty CLI_ARGS, so
+      # dropping either silently changes what this destroys.
+      - '{{ .MUTEX }} task -x playwright:regenerate:locked delete={{ .delete }} -- {{ .CLI_ARGS }}'
+
+  regenerate:locked:
+    cmds:
+      - task: install
       - |
         cd test/playwright
         # First capture all tests that have snapshots.
         TESTS=$(find . -name '*-snapshots' -type d | sed 's/-snapshots//' | sed 's/\.\///')
 
+        if [ -z "$TESTS" ]; then
+          echo "No *-snapshots directories found under test/playwright." >&2
+          echo "Nothing was run. Create the directory for a test before regenerating," >&2
+          echo "or run the test once so Playwright writes its first snapshot." >&2
+          exit 1
+        fi
+
+        DELETE='{{ .delete }}'
+        ARGS='{{ .CLI_ARGS }}'
+
+        # Deleting every snapshot and then regenerating a filtered subset
+        # leaves the rest missing, which looks like a regeneration that worked
+        # until the next full run. Make the caller say which they meant.
+        if [ -z "$DELETE" ]; then
+          if [ -n "$ARGS" ]; then
+            echo "Refusing to delete every snapshot for a filtered regeneration." >&2
+            echo "Pass delete=0 to keep the snapshots you are not regenerating," >&2
+            echo "or delete=1 if wiping all of them really is what you want." >&2
+            exit 1
+          fi
+          DELETE=1
+        fi
+
         # Remove snapshot files, but keep the directories. That way if tests
         # fail and this is rerun, we know what tests should have snapshots.
-        if [[ {{ .delete }} -eq 1 ]]; then
+        if [ "$DELETE" = "1" ]; then
           find . -name '*-snapshots' -type d | xargs -I {} -n1 /bin/sh -c 'rm -rf {}/*'
         fi
 
         # Run just tests with snapshots.
-        echo $TESTS | xargs npx playwright test --update-snapshots --retries 3
+        echo $TESTS | xargs npx playwright test --update-snapshots --retries 3 $ARGS
         echo "From your host, run the following from the project directory to add all changes to commit."
         echo "Be sure to review for unexpected changes, and don't be surprised if modified tests cause"
         echo "files to be renamed."

--- a/test/mutex.bats
+++ b/test/mutex.bats
@@ -1,0 +1,180 @@
+#!/usr/bin/env bats
+
+# mutex.bats — Unit tests for bin/playwright-mutex.
+#
+# Unlike the other files in this directory these need neither DDEV nor Docker:
+# the lock location is pointed at a temporary directory, so everything runs in
+# a couple of seconds.
+
+setup() {
+  MUTEX="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/bin/playwright-mutex"
+  export MUTEX
+
+  # Stands in for the ddev-global-cache mount point. The script expects the
+  # parent of the lock directory to exist and creates the rest itself.
+  VOLUME="$BATS_TEST_TMPDIR/volume"
+  LOCK_DIR="$VOLUME/playwright"
+  mkdir -p "$VOLUME"
+  export PLAYWRIGHT_MUTEX_DIR="$LOCK_DIR"
+
+  # Inherited state would make these tests pass or fail depending on the shell
+  # they were started from.
+  unset PLAYWRIGHT_MUTEX PLAYWRIGHT_MUTEX_WAIT PLAYWRIGHT_MUTEX_FAIL_FAST
+  unset PLAYWRIGHT_MUTEX_HELD CI
+  export DDEV_SITENAME=bats-project
+}
+
+teardown() {
+  if [ -n "${HOLDER_PID:-}" ]; then
+    kill "$HOLDER_PID" 2>/dev/null || true
+    wait "$HOLDER_PID" 2>/dev/null || true
+  fi
+}
+
+# Take the lock in a background process for a given number of seconds, and do
+# not return until it is actually held — otherwise the test races the holder.
+hold_lock() {
+  local seconds="${1:-10}"
+  mkdir -p "$LOCK_DIR"
+  : >"$LOCK_DIR/mutex.lock"
+  {
+    echo "project=other-project"
+    echo "pid=424242"
+    echo "started=$(($(date +%s) - 300))"
+    echo "started_human=$(date '+%Y-%m-%d %H:%M:%S')"
+    echo "command=npx playwright test"
+  } >"$LOCK_DIR/mutex.holder"
+
+  flock "$LOCK_DIR/mutex.lock" -c \
+    "touch '$BATS_TEST_TMPDIR/held'; sleep $seconds" >/dev/null 2>&1 &
+  HOLDER_PID=$!
+
+  local waited=0
+  while [ ! -f "$BATS_TEST_TMPDIR/held" ]; do
+    sleep 0.05
+    waited=$((waited + 1))
+    [ "$waited" -lt 200 ] || return 1
+  done
+}
+
+@test "mutex: exits 64 when given no command" {
+  run "$MUTEX"
+  [ "$status" -eq 64 ]
+  [[ "$output" == *"usage:"* ]]
+}
+
+@test "mutex: is off by default and never touches the lock" {
+  run "$MUTEX" echo hello
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+  [ ! -e "$LOCK_DIR" ]
+}
+
+@test "mutex: PLAYWRIGHT_MUTEX=0 runs the command unchanged" {
+  PLAYWRIGHT_MUTEX=0 run "$MUTEX" echo hello
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+
+@test "mutex: runs the command and takes the lock when enabled" {
+  PLAYWRIGHT_MUTEX=1 run "$MUTEX" echo hello
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+  [ -e "$LOCK_DIR/mutex.lock" ]
+}
+
+@test "mutex: propagates the command's exit status" {
+  PLAYWRIGHT_MUTEX=1 run "$MUTEX" sh -c 'exit 3'
+  [ "$status" -eq 3 ]
+}
+
+@test "mutex: releases the lock when the command finishes" {
+  PLAYWRIGHT_MUTEX=1 run "$MUTEX" true
+  [ "$status" -eq 0 ]
+
+  # A second run must not queue behind the first.
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_FAIL_FAST=1 run "$MUTEX" echo second
+  [ "$status" -eq 0 ]
+  [ "$output" = "second" ]
+}
+
+@test "mutex: releases the lock when the command is killed" {
+  PLAYWRIGHT_MUTEX=1 run "$MUTEX" sh -c 'kill -9 $$'
+  [ "$status" -ne 0 ]
+
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_FAIL_FAST=1 run "$MUTEX" echo after
+  [ "$status" -eq 0 ]
+  [ "$output" = "after" ]
+}
+
+@test "mutex: removes its holder breadcrumb afterwards" {
+  PLAYWRIGHT_MUTEX=1 run "$MUTEX" true
+  [ "$status" -eq 0 ]
+  [ ! -e "$LOCK_DIR/mutex.holder" ]
+}
+
+@test "mutex: exits 75 and names the holder when told not to wait" {
+  hold_lock 30
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_FAIL_FAST=1 run "$MUTEX" echo should-not-run
+  [ "$status" -eq 75 ]
+  [[ "$output" != *"should-not-run"* ]]
+  [[ "$output" == *"other-project"* ]]
+  [[ "$output" == *"for 5m"* ]]
+}
+
+@test "mutex: exits 75 once a bounded wait runs out" {
+  hold_lock 30
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_WAIT=1 run "$MUTEX" echo should-not-run
+  [ "$status" -eq 75 ]
+  [[ "$output" == *"waiting up to 1s"* ]]
+}
+
+@test "mutex: queues until the holder is done" {
+  hold_lock 2
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_WAIT=30 run "$MUTEX" echo ran-after-waiting
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ran-after-waiting"* ]]
+}
+
+@test "mutex: warns about a non-numeric wait" {
+  hold_lock 30
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_WAIT=soon PLAYWRIGHT_MUTEX_FAIL_FAST=1 \
+    run "$MUTEX" echo should-not-run
+  [ "$status" -eq 75 ]
+  [[ "$output" == *"non-numeric"* ]]
+}
+
+@test "mutex: passes nested invocations straight through" {
+  hold_lock 30
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_HELD=1 PLAYWRIGHT_MUTEX_FAIL_FAST=1 \
+    run "$MUTEX" echo nested
+  [ "$status" -eq 0 ]
+  [ "$output" = "nested" ]
+}
+
+@test "mutex: marks the command it runs as holding the lock" {
+  PLAYWRIGHT_MUTEX=1 run "$MUTEX" sh -c 'echo "$PLAYWRIGHT_MUTEX_HELD"'
+  [ "$status" -eq 0 ]
+  [ "$output" = "1" ]
+}
+
+@test "mutex: does nothing on CI" {
+  hold_lock 30
+  CI=true PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_FAIL_FAST=1 run "$MUTEX" echo on-ci
+  [ "$status" -eq 0 ]
+  [ "$output" = "on-ci" ]
+}
+
+@test "mutex: PLAYWRIGHT_MUTEX=force locks even on CI" {
+  hold_lock 30
+  CI=true PLAYWRIGHT_MUTEX=force PLAYWRIGHT_MUTEX_FAIL_FAST=1 run "$MUTEX" echo on-ci
+  [ "$status" -eq 75 ]
+}
+
+@test "mutex: warns and runs when the shared volume is absent" {
+  PLAYWRIGHT_MUTEX=1 PLAYWRIGHT_MUTEX_DIR="$BATS_TEST_TMPDIR/absent/playwright" \
+    run "$MUTEX" echo no-volume
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"no-volume"* ]]
+  [[ "$output" == *"is not mounted"* ]]
+}


### PR DESCRIPTION
definePlaywrightDrupalConfig() asks for `cpus - 2` workers, so one suite already claims nearly the whole machine. Each worktree is its own DDEV project, so two runs never see each other: they take longer than running back to back and starve each other into visual comparison failures that are really CPU starvation.

bin/playwright-mutex serialises runs by locking a file on the ddev-global-cache volume every DDEV project mounts - one inode on the host, so flock(2) is honoured across containers with no compose change and no restart. playwright:run, playwright:visualdiff and playwright:regenerate now delegate to hidden :locked tasks so the lock spans playwright:install as well as the run itself.

It is off unless PLAYWRIGHT_MUTEX=1, queues by default rather than refusing, and is skipped entirely when CI is set: hosted runners get a machine each, sharded runs are meant to overlap, and jobs sharing a self-hosted runner share this volume. PLAYWRIGHT_MUTEX_FAIL_FAST=1 gets the immediate exit 75 that suits a caller with other work to do, and PLAYWRIGHT_MUTEX=force overrides the CI skip.

Two supporting changes fall out of it:

- PLAYWRIGHT_WORKERS dials a single run down without editing a committed config file, which covers the case where somebody knows the machine is busy and no lock is wanted.
- The visualdiff and regenerate tasks now forward arguments after `--`, and bail when no -snapshots directories exist. xargs with an empty list still runs the command, and `playwright test` with no file filter runs the entire suite - a green result that tested far more than was asked for. A filtered regeneration also now requires an explicit delete=, since wiping every baseline to regenerate one leaves the rest missing.

The nested task call means exit statuses pass through `task -x`; a plain invocation still reports Task's own 201, as it did before.


Claude-Session: https://claude.ai/code/session_01QANQLodiYpVmEYm6hsc2Tx